### PR TITLE
feat: add Dockerfile and docker-compose

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,7 @@
 {
   "name": "Stock Tracker Dev",
-  "image": "mcr.microsoft.com/devcontainers/python:3.12",
+  "context": "..",
+  "dockerfile": "../Dockerfile",
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/node:1": {}

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+__pycache__/
+*.pyc
+.env
+.venv/
+venv/
+node_modules/
+dist/
+build/
+*.egg-info/
+.git/
+.github/
+tests/
+.coverage
+.pytest_cache/
+*.md
+!README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Backend Dockerfile
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy requirements first for better caching
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY app/ ./app/
+
+# Expose port
+EXPOSE 8000
+
+# Run the application
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,20 @@
+"""
+Stock Tracker API - Main Application
+"""
+from fastapi import FastAPI
+
+app = FastAPI(
+    title="Stock Tracker API",
+    description="API for tracking stock prices, managing watchlists and alerts",
+    version="1.0.0"
+)
+
+
+@app.get("/")
+async def root():
+    return {"message": "Stock Tracker API", "version": "1.0.0"}
+
+
+@app.get("/health")
+async def health():
+    return {"status": "healthy"}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,66 @@
+version: '3.8'
+
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: stock-tracker-backend
+    ports:
+      - "8000:8000"
+    environment:
+      - DATABASE_URL=postgresql://postgres:postgres@db:5432/stocktracker
+      - REDIS_URL=redis://redis:6379/0
+    depends_on:
+      - db
+      - redis
+    networks:
+      - stock-network
+    restart: unless-stopped
+
+  frontend:
+    build:
+      context: .
+      dockerfile: frontend/Dockerfile
+    container_name: stock-tracker-frontend
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend
+    networks:
+      - stock-network
+    restart: unless-stopped
+
+  db:
+    image: postgres:16-alpine
+    container_name: stock-tracker-db
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=stocktracker
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    networks:
+      - stock-network
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    container_name: stock-tracker-redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    networks:
+      - stock-network
+    restart: unless-stopped
+
+volumes:
+  postgres_data:
+  redis_data:
+
+networks:
+  stock-network:
+    driver: bridge

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+.env
+.git
+*.md
+!README.md
+tests/

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,29 @@
+# Frontend Dockerfile
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+
+# Install dependencies
+RUN npm ci
+
+# Copy source code
+COPY . .
+
+# Build the application
+RUN npm run build
+
+# Production stage
+FROM nginx:alpine
+
+# Copy built assets
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+# Copy nginx config
+COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 3000
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,16 @@
+server {
+    listen 3000;
+    server_name localhost;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location /api/ {
+        proxy_pass http://backend:8000/api/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}


### PR DESCRIPTION
## Summary

Add Docker support for deployment and development.

### Changes
- Add Dockerfile for backend (Python 3.12-slim)
- Add Dockerfile for frontend (Node 20 + nginx)
- Add docker-compose.yml with:
  - backend (FastAPI)
  - frontend (nginx)
  - postgres (database)
  - redis (cache)
- Update devcontainer to build from Dockerfile
- Add .dockerignore files
- Add nginx config for frontend routing
- Add app/main.py entry point

**CI passed - self-merge**