### PR TITLE
fix: use --legacy-peer-deps in frontend Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install dependencies
-RUN npm install
+RUN npm install --legacy-peer-deps
 
 # Copy source code
 COPY src ./src


### PR DESCRIPTION
Add --legacy-peer-deps to npm install in frontend Dockerfile to resolve vite@8 / @vitejs/plugin-react peer dependency conflict.

This allows the Docker build to succeed while the proper fix (upgrading @vitejs/plugin-react) is prepared.