### PR TITLE
fix: Python 3.9 compatibility for alert_service

### DIFF
--- a/app/services/alert_service.py
+++ b/app/services/alert_service.py
@@ -3,6 +3,7 @@ Alert Service - Price Alert Feature
 
 Provides price alert management for users to monitor stock prices.
 """
+from __future__ import annotations
 
 import uuid
 from dataclasses import dataclass


### PR DESCRIPTION
Add `from __future__ import annotations` to fix Python 3.9 compatibility issue with union type syntax.

All 61 tests pass.