### PR TITLE
feat: add market overview section to Dashboard

### DIFF
--- a/frontend/src/pages/Dashboard.css
+++ b/frontend/src/pages/Dashboard.css
@@ -9,24 +9,43 @@
   color: #e53935;
 }
 
+.dashboard h3 {
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+  font-size: 1.1rem;
+  color: #374151;
+}
+
+.dashboard section:first-of-type h3 {
+  margin-top: 0;
+}
+
 .stock-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-  gap: 1.5rem;
-  margin-top: 1.5rem;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.indices-grid {
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
 }
 
 .stock-card {
   background: white;
   border-radius: 8px;
-  padding: 1.5rem;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  padding: 1rem;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
   transition: transform 0.2s, box-shadow 0.2s;
 }
 
 .stock-card:hover {
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+}
+
+.index-card {
+  border-left: 3px solid #2563eb;
 }
 
 .stock-header {
@@ -37,9 +56,51 @@
 }
 
 .stock-symbol {
-  font-size: 1.25rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #1a1a2e;
+}
+
+.market-badge {
+  font-size: 0.7rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  font-weight: 500;
+}
+
+.market-badge.premarket,
+.market-badge.extendedhours {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.market-badge.regular {
+  background: #d1fae5;
+  color: #065f46;
+}
+
+.stock-market-state {
+  font-size: 0.75rem;
+  color: #666;
+  background: #f3f4f6;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+}
+
+.stock-price {
+  font-size: 1.5rem;
   font-weight: 700;
   color: #1a1a2e;
+}
+
+.index-card .stock-price {
+  font-size: 1.25rem;
+}
+
+.stock-volume {
+  font-size: 0.85rem;
+  color: #6b7280;
+  margin-top: 0.25rem;
 }
 
 .stock-exchange {

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -3,32 +3,40 @@ import { stockService } from '../services/api'
 import type { StockQuote } from '../services/api'
 import './Dashboard.css'
 
+// Major market indices
+const MARKET_INDICES = [
+  { symbol: '^GSPC', name: 'S&P 500' },
+  { symbol: '^IXIC', name: 'Nasdaq' },
+  { symbol: '^DJI', name: 'Dow Jones' },
+  { symbol: '^TNX', name: '10Y Treasury' },
+]
+
 function Dashboard() {
   const [quotes, setQuotes] = useState<StockQuote[]>([])
+  const [indices, setIndices] = useState<StockQuote[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
-    loadWatchlistStocks()
+    loadAll()
   }, [])
 
-  const loadWatchlistStocks = async () => {
+  const loadAll = async () => {
     try {
       setLoading(true)
       setError(null)
-      // Demo stocks - in production would come from user's watchlist
+
+      // Load watchlist stocks
       const demoSymbols = ['AAPL', 'GOOGL', 'MSFT', 'TSLA']
-      
-      const results = await Promise.all(
-        demoSymbols.map(async (symbol) => {
-          const quote = await stockService.getStockQuote(symbol)
-          return quote
-        })
-      )
-      
-      setQuotes(results.filter((q): q is StockQuote => q !== null))
+      const [watchlistResults, indexResults] = await Promise.all([
+        Promise.all(demoSymbols.map(s => stockService.getStockQuote(s))),
+        Promise.all(MARKET_INDICES.map(i => stockService.getStockQuote(i.symbol))),
+      ])
+
+      setQuotes(watchlistResults.filter((q): q is StockQuote => q !== null))
+      setIndices(indexResults.filter((q): q is StockQuote => q !== null))
     } catch (err) {
-      setError('Failed to load stocks')
+      setError('Failed to load data')
     } finally {
       setLoading(false)
     }
@@ -45,21 +53,48 @@ function Dashboard() {
   return (
     <div className="dashboard">
       <h2>Dashboard</h2>
+
+      {/* Market Overview */}
+      {indices.length > 0 && (
+        <section className="market-section">
+          <h3>Market Overview</h3>
+          <div className="stock-grid indices-grid">
+            {indices.map((quote, i) => (
+              <div key={quote.symbol} className="stock-card index-card">
+                <div className="stock-header">
+                  <span className="stock-symbol">{MARKET_INDICES[i]?.name || quote.symbol}</span>
+                  <span className={`market-badge ${quote.market_state?.toLowerCase()}`}>
+                    {quote.market_state || 'Unknown'}
+                  </span>
+                </div>
+                <div className="stock-price">
+                  ${quote.price.toFixed(2)}
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Watchlist */}
       {quotes.length === 0 ? (
         <p className="empty-state">No stocks to display. Add stocks to your watchlist.</p>
       ) : (
-        <div className="stock-grid">
-          {quotes.map(quote => (
-            <div key={quote.symbol} className="stock-card">
-              <div className="stock-header">
-                <span className="stock-symbol">{quote.symbol}</span>
-                <span className="stock-market-state">{quote.market_state || 'Unknown'}</span>
+        <section className="watchlist-section">
+          <h3>My Watchlist</h3>
+          <div className="stock-grid">
+            {quotes.map(quote => (
+              <div key={quote.symbol} className="stock-card">
+                <div className="stock-header">
+                  <span className="stock-symbol">{quote.symbol}</span>
+                  <span className="stock-market-state">{quote.market_state || 'Unknown'}</span>
+                </div>
+                <div className="stock-price">${quote.price.toFixed(2)}</div>
+                <div className="stock-volume">Vol: {quote.volume.toLocaleString()}</div>
               </div>
-              <div className="stock-price">${quote.price.toFixed(2)}</div>
-              <div className="stock-volume">Vol: {quote.volume.toLocaleString()}</div>
-            </div>
-          ))}
-        </div>
+            ))}
+          </div>
+        </section>
       )}
     </div>
   )


### PR DESCRIPTION
Add market overview to Dashboard showing major indices:

1. **Market Indices** - S&P 500, Nasdaq, Dow Jones, 10Y Treasury
2. **Parallel API loading** - faster page load with Promise.all
3. **Market status badges** - visual indicator for premarket/regular/extended hours
4. **Improved card sizing** - smaller cards for indices, better grid layout