### PR TITLE
feat: add ErrorBoundary component to prevent page crashes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Routes, Route, NavLink } from 'react-router-dom'
+import ErrorBoundary from './components/ErrorBoundary'
 import Dashboard from './pages/Dashboard'
 import Watchlist from './pages/Watchlist'
 import Alerts from './pages/Alerts'
@@ -19,12 +20,14 @@ function App() {
           </ul>
         </nav>
         <main className="main-content">
-          <Routes>
-            <Route path="/" element={<Dashboard />} />
-            <Route path="/search" element={<StockSearch />} />
-            <Route path="/watchlist" element={<Watchlist />} />
-            <Route path="/alerts" element={<Alerts />} />
-          </Routes>
+          <ErrorBoundary>
+            <Routes>
+              <Route path="/" element={<Dashboard />} />
+              <Route path="/search" element={<StockSearch />} />
+              <Route path="/watchlist" element={<Watchlist />} />
+              <Route path="/alerts" element={<Alerts />} />
+            </Routes>
+          </ErrorBoundary>
         </main>
       </div>
     </BrowserRouter>

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,65 @@
+import { Component, type ReactNode } from 'react'
+
+interface Props {
+  children: ReactNode
+  fallback?: ReactNode
+}
+
+interface State {
+  hasError: boolean
+  error: Error | null
+}
+
+class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = { hasError: false, error: null }
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error('ErrorBoundary caught:', error, errorInfo)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        this.props.fallback || (
+          <div style={{
+            padding: '2rem',
+            textAlign: 'center',
+            background: '#fff',
+            borderRadius: '8px',
+            margin: '1rem',
+            border: '1px solid #e5e7eb'
+          }}>
+            <h3 style={{ color: '#e53935', marginBottom: '0.5rem' }}>Something went wrong</h3>
+            <p style={{ color: '#666', marginBottom: '1rem' }}>
+              {this.state.error?.message || 'An unexpected error occurred'}
+            </p>
+            <button
+              onClick={() => window.location.reload()}
+              style={{
+                padding: '0.5rem 1rem',
+                background: '#1a1a2e',
+                color: 'white',
+                border: 'none',
+                borderRadius: '4px',
+                cursor: 'pointer'
+              }}
+            >
+              Reload Page
+            </button>
+          </div>
+        )
+      )
+    }
+
+    return this.props.children
+  }
+}
+
+export default ErrorBoundary


### PR DESCRIPTION
## Summary

Add React ErrorBoundary to wrap all routes and prevent component crashes.

## Changes

1. **ErrorBoundary component** - Catches React errors and displays graceful fallback
2. **App.tsx wrapped** - All routes wrapped with ErrorBoundary
3. **Fallback UI** - Shows error message + reload button
4. **Console logging** - Logs errors for debugging