### PR TITLE
feat: add price change display and loading skeletons

### DIFF
--- a/app/api/v1/stocks.py
+++ b/app/api/v1/stocks.py
@@ -39,6 +39,8 @@ async def get_stock_quote(symbol: str) -> StockQuoteResponse:
                 volume=quote.volume,
                 timestamp=quote.timestamp,
                 market_state=quote.market_state,
+                change=quote.change,
+                change_percent=quote.change_percent,
             )
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to fetch quote: {str(e)}")

--- a/app/schemas/schemas.py
+++ b/app/schemas/schemas.py
@@ -18,6 +18,8 @@ class StockQuoteResponse(BaseModel):
     volume: int
     timestamp: Optional[int] = None
     market_state: Optional[str] = None
+    change: Optional[float] = None
+    change_percent: Optional[float] = None
 
 
 class StockHistoryResponse(BaseModel):

--- a/app/services/yfinance_service.py
+++ b/app/services/yfinance_service.py
@@ -27,6 +27,8 @@ class StockQuote:
     volume: int
     timestamp: Optional[int] = None
     market_state: Optional[str] = None
+    change: Optional[float] = None
+    change_percent: Optional[float] = None
 
 
 @dataclass
@@ -172,6 +174,8 @@ class YFinanceService:
             volume=meta.get("regularMarketVolume", 0),
             timestamp=int(meta.get("regularMarketTime", 0)),
             market_state=meta.get("marketState", "UNKNOWN"),
+            change=meta.get("regularMarketChange", None),
+            change_percent=meta.get("regularMarketChangePercent", None),
         )
 
     async def get_history(

--- a/frontend/src/components/Skeleton.css
+++ b/frontend/src/components/Skeleton.css
@@ -1,0 +1,37 @@
+@keyframes shimmer {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}
+
+.skeleton {
+  background: linear-gradient(
+    90deg,
+    #f0f0f0 25%,
+    #e0e0e0 50%,
+    #f0f0f0 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+}
+
+.stock-card-skeleton {
+  background: white;
+  border-radius: 8px;
+  padding: 1rem;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+}
+
+.skeleton-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.skeleton-price {
+  margin: 0.5rem 0;
+}

--- a/frontend/src/components/Skeleton.tsx
+++ b/frontend/src/components/Skeleton.tsx
@@ -1,0 +1,30 @@
+import './Skeleton.css'
+
+interface SkeletonProps {
+  width?: string
+  height?: string
+  borderRadius?: string
+  className?: string
+}
+
+export function Skeleton({ width = '100%', height = '20px', borderRadius = '4px', className = '' }: SkeletonProps) {
+  return (
+    <div
+      className={`skeleton ${className}`}
+      style={{ width, height, borderRadius }}
+    />
+  )
+}
+
+export function StockCardSkeleton() {
+  return (
+    <div className="stock-card-skeleton">
+      <div className="skeleton-header">
+        <Skeleton width="80px" height="20px" />
+        <Skeleton width="60px" height="16px" borderRadius="12px" />
+      </div>
+      <Skeleton width="120px" height="32px" borderRadius="4px" className="skeleton-price" />
+      <Skeleton width="100px" height="14px" />
+    </div>
+  )
+}

--- a/frontend/src/pages/Dashboard.css
+++ b/frontend/src/pages/Dashboard.css
@@ -97,6 +97,20 @@
   font-size: 1.25rem;
 }
 
+.stock-change {
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin-top: 0.25rem;
+}
+
+.stock-change.up {
+  color: #10b981;
+}
+
+.stock-change.down {
+  color: #ef4444;
+}
+
 .stock-volume {
   font-size: 0.85rem;
   color: #6b7280;

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { stockService } from '../services/api'
 import type { StockQuote } from '../services/api'
+import { StockCardSkeleton } from '../components/Skeleton'
 import './Dashboard.css'
 
 // Major market indices
@@ -10,6 +11,13 @@ const MARKET_INDICES = [
   { symbol: '^DJI', name: 'Dow Jones' },
   { symbol: '^TNX', name: '10Y Treasury' },
 ]
+
+function formatChange(change: number | undefined, percent: number | undefined) {
+  if (change === undefined || change === null) return null
+  const sign = change >= 0 ? '+' : ''
+  const pctStr = percent !== undefined ? ` (${sign}${percent.toFixed(2)}%)` : ''
+  return `${sign}${change.toFixed(2)}${pctStr}`
+}
 
 function Dashboard() {
   const [quotes, setQuotes] = useState<StockQuote[]>([])
@@ -43,7 +51,23 @@ function Dashboard() {
   }
 
   if (loading) {
-    return <div className="loading">Loading...</div>
+    return (
+      <div className="dashboard">
+        <h2>Dashboard</h2>
+        <section className="market-section">
+          <h3>Market Overview</h3>
+          <div className="stock-grid indices-grid">
+            {[1, 2, 3, 4].map(i => <StockCardSkeleton key={i} />)}
+          </div>
+        </section>
+        <section className="watchlist-section">
+          <h3>My Watchlist</h3>
+          <div className="stock-grid">
+            {[1, 2, 3, 4].map(i => <StockCardSkeleton key={i} />)}
+          </div>
+        </section>
+      </div>
+    )
   }
 
   if (error) {
@@ -59,19 +83,26 @@ function Dashboard() {
         <section className="market-section">
           <h3>Market Overview</h3>
           <div className="stock-grid indices-grid">
-            {indices.map((quote, i) => (
-              <div key={quote.symbol} className="stock-card index-card">
-                <div className="stock-header">
-                  <span className="stock-symbol">{MARKET_INDICES[i]?.name || quote.symbol}</span>
-                  <span className={`market-badge ${quote.market_state?.toLowerCase()}`}>
-                    {quote.market_state || 'Unknown'}
-                  </span>
+            {indices.map((quote, i) => {
+              const changeStr = formatChange(quote.change, quote.change_percent)
+              const isUp = (quote.change ?? 0) >= 0
+              return (
+                <div key={quote.symbol} className="stock-card index-card">
+                  <div className="stock-header">
+                    <span className="stock-symbol">{MARKET_INDICES[i]?.name || quote.symbol}</span>
+                    <span className={`market-badge ${quote.market_state?.toLowerCase()}`}>
+                      {quote.market_state || 'Unknown'}
+                    </span>
+                  </div>
+                  <div className="stock-price">${quote.price.toFixed(2)}</div>
+                  {changeStr && (
+                    <div className={`stock-change ${isUp ? 'up' : 'down'}`}>
+                      {changeStr}
+                    </div>
+                  )}
                 </div>
-                <div className="stock-price">
-                  ${quote.price.toFixed(2)}
-                </div>
-              </div>
-            ))}
+              )
+            })}
           </div>
         </section>
       )}
@@ -83,16 +114,25 @@ function Dashboard() {
         <section className="watchlist-section">
           <h3>My Watchlist</h3>
           <div className="stock-grid">
-            {quotes.map(quote => (
-              <div key={quote.symbol} className="stock-card">
-                <div className="stock-header">
-                  <span className="stock-symbol">{quote.symbol}</span>
-                  <span className="stock-market-state">{quote.market_state || 'Unknown'}</span>
+            {quotes.map(quote => {
+              const changeStr = formatChange(quote.change, quote.change_percent)
+              const isUp = (quote.change ?? 0) >= 0
+              return (
+                <div key={quote.symbol} className="stock-card">
+                  <div className="stock-header">
+                    <span className="stock-symbol">{quote.symbol}</span>
+                    <span className="stock-market-state">{quote.market_state || 'Unknown'}</span>
+                  </div>
+                  <div className="stock-price">${quote.price.toFixed(2)}</div>
+                  {changeStr && (
+                    <div className={`stock-change ${isUp ? 'up' : 'down'}`}>
+                      {changeStr}
+                    </div>
+                  )}
+                  <div className="stock-volume">Vol: {quote.volume.toLocaleString()}</div>
                 </div>
-                <div className="stock-price">${quote.price.toFixed(2)}</div>
-                <div className="stock-volume">Vol: {quote.volume.toLocaleString()}</div>
-              </div>
-            ))}
+              )
+            })}
           </div>
         </section>
       )}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -14,6 +14,8 @@ export interface StockQuote {
   volume: number
   timestamp?: number
   market_state?: string
+  change?: number
+  change_percent?: number
 }
 
 export interface StockHistory {


### PR DESCRIPTION
## Summary

Add loading skeleton states and price change indicators.

## Backend

1. **StockQuote** - Add `change` and `change_percent` fields
2. **Yahoo Finance** - Extract `regularMarketChange` and `regularMarketChangePercent`

## Frontend

1. **Skeleton component** - Shimmer loading animation for stock cards
2. **Price change display** - Shows +/- with green (up) / red (down) colors
3. **Dashboard** - Displays change data for indices and watchlist stocks
4. **StockCardSkeleton** - Pre-built skeleton for loading states

All 61 tests pass ✅