### PR TITLE
feat: add chart period selector (1W/1M/3M/6M) to search page

### DIFF
--- a/PROJECT_TASKS.md
+++ b/PROJECT_TASKS.md
@@ -85,6 +85,11 @@ A web-based stock tracking system for Taiwan market with:
 | Python 3.9 Fix | #33 | `from __future__ import annotations` for union types |
 | Structured Logging | #34 | JSON-like logging format + enhanced /health |
 | Plugin Fix | #32 | `@vitejs/plugin-react` 5.x for vite 8 |
+| Price Change + Skeletons | #43 | Real-time price change display + loading skeletons |
+| Search Autocomplete | #41 | Search with autocomplete + popular stocks suggestions |
+| ErrorBoundary | #42 | React ErrorBoundary to prevent page crashes |
+
+**develop branch: CLEAN ✅ | CI: ALL GREEN ✅** |
 
 ---
 

--- a/frontend/src/pages/StockSearch.css
+++ b/frontend/src/pages/StockSearch.css
@@ -206,3 +206,61 @@
 .create-alert-btn:hover {
   background: #43a047;
 }
+
+/* Chart section */
+.chart-section {
+  margin-top: 1.5rem;
+}
+
+.chart-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.chart-header h4 {
+  margin: 0;
+  font-size: 1rem;
+  color: #374151;
+}
+
+.period-selector {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.period-btn {
+  padding: 0.3rem 0.6rem;
+  border: 1px solid #e5e7eb;
+  background: white;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #666;
+  transition: all 0.2s;
+}
+
+.period-btn:hover:not(:disabled) {
+  background: #f9fafb;
+}
+
+.period-btn.active {
+  background: #2563eb;
+  color: white;
+  border-color: #2563eb;
+}
+
+.period-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.chart-loading {
+  padding: 3rem;
+  text-align: center;
+  color: #9ca3af;
+  background: #f9fafb;
+  border-radius: 8px;
+}

--- a/frontend/src/pages/StockSearch.tsx
+++ b/frontend/src/pages/StockSearch.tsx
@@ -1,4 +1,7 @@
-import { useState, useRef } from 'react'
+import {
+  useState,
+  useRef,
+} from 'react'
 import { stockService, watchlistService, alertService } from '../services/api'
 import type { StockQuote, StockHistory, AlertConditionType } from '../services/api'
 import StockIndicators from '../components/StockIndicators'
@@ -21,17 +24,28 @@ const POPULAR_STOCKS = [
   { symbol: 'JNJ', name: 'Johnson & Johnson' },
 ]
 
+type Period = '1W' | '1M' | '3M' | '6M'
+
+const PERIOD_MAP: Record<Period, { period: string; interval: string }> = {
+  '1W': { period: '5d', interval: '30m' },
+  '1M': { period: '1mo', interval: '1d' },
+  '3M': { period: '3mo', interval: '1d' },
+  '6M': { period: '6mo', interval: '1d' },
+}
+
 function StockSearch() {
   const [symbol, setSymbol] = useState('')
   const [quote, setQuote] = useState<StockQuote | null>(null)
   const [history, setHistory] = useState<StockHistory | null>(null)
   const [loading, setLoading] = useState(false)
+  const [chartLoading, setChartLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [addedToWatchlist, setAddedToWatchlist] = useState(false)
   const [alertType, setAlertType] = useState<AlertConditionType>('above')
   const [alertThreshold, setAlertThreshold] = useState('')
   const [message, setMessage] = useState<string | null>(null)
   const [showSuggestions, setShowSuggestions] = useState(false)
+  const [period, setPeriod] = useState<Period>('1M')
   const inputRef = useRef<HTMLInputElement>(null)
 
   // Filter suggestions based on input
@@ -51,6 +65,17 @@ function StockSearch() {
     form?.requestSubmit()
   }
 
+  const fetchHistory = async (sym: string, p: Period) => {
+    const { period: pPeriod, interval: pInterval } = PERIOD_MAP[p]
+    setChartLoading(true)
+    try {
+      const historyData = await stockService.getStockHistory(sym, pPeriod, pInterval)
+      setHistory(historyData)
+    } finally {
+      setChartLoading(false)
+    }
+  }
+
   const handleSearch = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!symbol.trim()) return
@@ -65,8 +90,7 @@ function StockSearch() {
       if (result) {
         setQuote(result)
         setAlertThreshold(result.price.toString())
-        const historyData = await stockService.getStockHistory(symbol.toUpperCase(), '1mo', '1d')
-        setHistory(historyData)
+        await fetchHistory(symbol.toUpperCase(), period)
       } else {
         setError('Stock not found')
         setQuote(null)
@@ -76,6 +100,13 @@ function StockSearch() {
       setQuote(null)
     } finally {
       setLoading(false)
+    }
+  }
+
+  const handlePeriodChange = async (p: Period) => {
+    setPeriod(p)
+    if (quote) {
+      await fetchHistory(quote.symbol, p)
     }
   }
 
@@ -209,7 +240,30 @@ function StockSearch() {
 
           <StockIndicators symbol={quote.symbol} />
 
-          {history && <StockChart data={history} symbol={quote.symbol} />}
+          {history && (
+            <div className="chart-section">
+              <div className="chart-header">
+                <h4>Price Chart</h4>
+                <div className="period-selector">
+                  {(['1W', '1M', '3M', '6M'] as Period[]).map(p => (
+                    <button
+                      key={p}
+                      className={`period-btn ${period === p ? 'active' : ''}`}
+                      onClick={() => handlePeriodChange(p)}
+                      disabled={chartLoading}
+                    >
+                      {p}
+                    </button>
+                  ))}
+                </div>
+              </div>
+              {chartLoading ? (
+                <div className="chart-loading">Loading chart...</div>
+              ) : (
+                <StockChart data={history} symbol={quote.symbol} />
+              )}
+            </div>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

Add period selector for the price chart to allow viewing different time ranges.

## Features

1. **Period buttons** - 1W, 1M, 3M, 6M buttons above chart
2. **No re-search** - Changing period only fetches new chart data, keeps current quote
3. **Loading state** - Shows "Loading chart..." during period change
4. **Smart intervals** - Uses appropriate intervals:
   - 1W: 5 days, 30 min intervals
   - 1M: 1 month, daily
   - 3M: 3 months, daily
   - 6M: 6 months, daily