### PR TITLE
fix: add rewrites for SPA routing on Vercel (#52)

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -38,6 +38,9 @@
   "regions": [
     "sin1"
   ],
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ],
   "env": {
     "VITE_API_BASE_URL": "https://stock-tracker-api-5ht7.onrender.com/api/v1"
   }


### PR DESCRIPTION
## Summary\n\nAdd  configuration to  to support client-side routing (React Router).\n\nWithout this, all non-root paths (, , ) return 404 on Vercel.\n\n## Fix\n\n\n\n## Testing\n\n- [x] Local  still works\n- [ ] Vercel deployment needs to be verified after merge\n\nCloses #52