### PR TITLE
fix: handle undefined RSI in StockIndicators component

### DIFF
--- a/frontend/src/components/StockIndicators.tsx
+++ b/frontend/src/components/StockIndicators.tsx
@@ -44,15 +44,15 @@ function StockIndicators({ symbol, period = '3mo', interval = '1d' }: StockIndic
     return <div className="indicators-error">{error || 'No data'}</div>
   }
 
-  const getRsiColor = (rsi: number | null) => {
-    if (rsi === null) return ''
+  const getRsiColor = (rsi: number | null | undefined) => {
+    if (rsi == null) return ''
     if (rsi >= 70) return 'overbought'
     if (rsi <= 30) return 'oversold'
     return ''
   }
 
-  const getRsiLabel = (rsi: number | null) => {
-    if (rsi === null) return 'N/A'
+  const getRsiLabel = (rsi: number | null | undefined) => {
+    if (rsi == null) return 'N/A'
     if (rsi >= 70) return 'Overbought'
     if (rsi <= 30) return 'Oversold'
     return 'Neutral'
@@ -67,7 +67,7 @@ function StockIndicators({ symbol, period = '3mo', interval = '1d' }: StockIndic
         <div className={`indicator-card ${getRsiColor(indicators.rsi)}`}>
           <div className="indicator-label">RSI (14)</div>
           <div className="indicator-value">
-            {indicators.rsi !== null ? indicators.rsi.toFixed(2) : 'N/A'}
+            {indicators.rsi != null ? indicators.rsi.toFixed(2) : 'N/A'}
           </div>
           <div className="indicator-status">
             {getRsiLabel(indicators.rsi)}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -31,7 +31,7 @@ export interface StockHistory {
 // Indicator types
 export interface StockIndicators {
   symbol: string
-  rsi: number | null
+  rsi: number | null | undefined
   macd: {
     macd_line: number
     signal_line: number


### PR DESCRIPTION
RSI value from API could be undefined (not just null),
causing 'undefined is not an object (evaluating r.rsi.toFixed)' error.

Changes:
- Use != null instead of !== null to catch both null and undefined
- Update type definition to allow undefined
- Update getRsiColor and getRsiLabel to accept undefined
