### PR TITLE
fix: update VITE_API_BASE_URL to stock-api.tienyulin.com

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -42,6 +42,6 @@
     { "source": "/(.*)", "destination": "/index.html" }
   ],
   "env": {
-    "VITE_API_BASE_URL": "https://stock-tracker-api-5ht7.onrender.com/api/v1"
+    "VITE_API_BASE_URL": "https://stock-api.tienyulin.com/api/v1"
   }
 }


### PR DESCRIPTION
Fix Issue #63: Update VITE_API_BASE_URL from old onrender.com to stock-api.tienyulin.com