### PR TITLE
fix: flatten indicators response to match frontend contract

### DIFF
--- a/app/api/v1/stocks.py
+++ b/app/api/v1/stocks.py
@@ -217,7 +217,7 @@ async def get_stock_indicators(
                 "symbol": symbol.upper(),
                 "period": period,
                 "interval": interval,
-                "indicators": indicators,
+                **indicators,
             }
     except HTTPException:
         raise


### PR DESCRIPTION
Fix Issue #64: RSI/MACD/SMA/EMA were nested under 'indicators' key but frontend expected them at top level.