### PR TITLE
fix: auto-create database tables on API startup

### DIFF
--- a/app/core/init_db.py
+++ b/app/core/init_db.py
@@ -1,0 +1,32 @@
+"""
+Database initialization script.
+Creates all tables if they don't exist.
+"""
+
+import logging
+from sqlalchemy import text
+
+from app.core.database import engine, Base
+from app.models import Alert, AlertNotification, User, Watchlist, WatchlistItem
+
+logger = logging.getLogger(__name__)
+
+
+async def init_db() -> None:
+    """Create all database tables."""
+    logger.info("Initializing database tables...")
+    async with engine.begin() as conn:
+        # Create all tables defined in models
+        await conn.run_sync(Base.metadata.create_all)
+    logger.info("Database tables initialized successfully.")
+
+
+async def check_db_connection() -> bool:
+    """Check if database connection is working."""
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(text("SELECT 1"))
+        return True
+    except Exception as e:
+        logger.error(f"Database connection failed: {e}")
+        return False

--- a/app/main.py
+++ b/app/main.py
@@ -11,6 +11,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.api.v1.router import router as api_v1_router
 from app.api.v1 import websocket
+from app.core.init_db import init_db
 
 # Configure structured logging
 logging.basicConfig(
@@ -26,6 +27,7 @@ logger = logging.getLogger(__name__)
 async def lifespan(app: FastAPI):
     """Application lifespan events."""
     logger.info("Stock Tracker API starting up...")
+    await init_db()
     yield
     logger.info("Stock Tracker API shutting down...")
 


### PR DESCRIPTION
Fix Issue #65: Add init_db() call on FastAPI startup to auto-create all tables (Watchlist, Alert, User, etc.)