### PR TITLE
fix: handle asyncpg SSL connection for Render PostgreSQL

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -11,6 +11,9 @@ class Settings(BaseSettings):
 
     def _fix_database_url(url: str) -> str:
         """Convert postgresql:// to postgresql+asyncpg:// for SQLAlchemy async."""
+        # Remove sslmode from URL - asyncpg handles SSL differently
+        if "?sslmode=" in url:
+            url = url.split("?sslmode=")[0]
         if url.startswith("postgresql://") and "+asyncpg" not in url:
             return url.replace("postgresql://", "postgresql+asyncpg://", 1)
         return url

--- a/app/core/database.py
+++ b/app/core/database.py
@@ -18,6 +18,13 @@ engine = create_async_engine(
     settings.database_url,
     echo=False,
     pool_pre_ping=True,
+    connect_args={
+        "server_settings": {
+            "jit": "off"
+        },
+        # SSL required for Render PostgreSQL
+        "ssl": True,
+    },
 )
 
 AsyncSessionLocal = async_sessionmaker(


### PR DESCRIPTION
Fix: Strip sslmode from DATABASE_URL and pass SSL=True to asyncpg connect_args for Render PostgreSQL compatibility.