### PR TITLE
fix: render deploy from main branch

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -8,7 +8,7 @@ services:
     env: python
     region: singapore
     plan: free
-    branch: develop
+    branch: main
     repo: https://github.com/tienyulin/stock-tracker.git
     rootDirectory: .
     buildCommand: pip install -r requirements.txt --prefer-binary


### PR DESCRIPTION
## Summary
Change render.yaml to deploy from main branch instead of develop.

## Testing
Render will now deploy from main branch.