### PR TITLE
fix: strip query params in database.py before engine creation

### DIFF
--- a/app/core/database.py
+++ b/app/core/database.py
@@ -2,8 +2,10 @@
 Async database connection using SQLAlchemy 2.0.
 """
 
+import ssl
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine, async_sessionmaker
 from sqlalchemy.orm import DeclarativeBase
+from sqlalchemy import URL
 
 from app.core.config import settings
 
@@ -14,24 +16,39 @@ class Base(DeclarativeBase):
     pass
 
 
+# Parse the database URL and ensure no query params are passed to asyncpg
+# asyncpg.connect() does NOT accept sslmode - it only accepts ssl (boolean)
+_database_url = settings.database_url
+if "?" in _database_url:
+    # Strip ALL query params - asyncpg doesn't support them
+    # They were causing: TypeError: connect() got an unexpected keyword argument 'sslmode'
+    _database_url = _database_url.split("?")[0]
+    print(f"[DB] Stripped query params from database URL")
+
+# Convert postgresql:// to postgresql+asyncpg:// if needed
+if _database_url.startswith("postgresql://") and "+asyncpg" not in _database_url:
+    _database_url = _database_url.replace("postgresql://", "postgresql+asyncpg://", 1)
+    print(f"[DB] Converted driver to asyncpg")
+
 # Determine SSL requirement based on host
-# Render/Neon requires SSL, local Docker does not
 _is_remote_db = not any(
-    host in settings.database_url.lower()
+    host in _database_url.lower()
     for host in ["localhost", "host.docker.internal", "db:", "127.0.0.1"]
 )
 
-_connect_args = {
+_connect_args: dict = {
     "server_settings": {
         "jit": "off"
     },
 }
 if _is_remote_db:
     # Remote databases (Render, Neon, etc.) require SSL
+    # Use ssl=True (boolean) - asyncpg.connect() accepts this, NOT sslmode
     _connect_args["ssl"] = True
+    print(f"[DB] Enabled SSL for remote database")
 
 engine = create_async_engine(
-    settings.database_url,
+    _database_url,
     echo=False,
     pool_pre_ping=True,
     connect_args=_connect_args,


### PR DESCRIPTION
## Summary
Additional safety fix for 'sslmode' error on Render.

Problem: asyncpg.connect() doesn't accept 'sslmode' parameter.
We were relying on config._fix_database_url() but SQLAlchemy
might still parse query params from the URL string.

Solution: Strip query params directly in database.py as a safety net,
with debug logging.