### PR TITLE
feat: LINE Notify integration for stock alerts

### DIFF
--- a/app/api/v1/alerts.py
+++ b/app/api/v1/alerts.py
@@ -165,6 +165,31 @@ async def trigger_alert(
     await db.commit()
     await db.refresh(alert)
 
+    # Send LINE notification (async, non-blocking)
+    from app.services.line_notify_service import notify_alert_triggered
+    try:
+        # Get current price for notification
+        from app.services.yfinance_service import get_quote
+        quote = await get_quote(alert.symbol)
+        current_price = quote.get("regularMarketPrice") or quote.get("price") or alert.threshold
+    except Exception:
+        current_price = alert.threshold
+    
+    # Fire and forget - don't block the response
+    try:
+        await notify_alert_triggered(
+            db=db,
+            user_id=str(alert.user_id),
+            symbol=alert.symbol,
+            condition_type=alert.condition_type,
+            threshold=alert.threshold,
+            current_price=float(current_price)
+        )
+    except Exception as e:
+        # Log but don't fail the request
+        import logging
+        logging.getLogger(__name__).warning(f"Failed to send LINE notification: {e}")
+
     return AlertResponse(
         id=alert.id,
         symbol=alert.symbol,

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -4,7 +4,7 @@ API v1 router.
 
 from fastapi import APIRouter
 
-from app.api.v1 import alerts, auth, stocks, watchlists
+from app.api.v1 import alerts, auth, stocks, watchlists, users
 
 router = APIRouter(prefix="/api/v1")
 
@@ -12,3 +12,4 @@ router.include_router(auth.router)
 router.include_router(stocks.router)
 router.include_router(watchlists.router)
 router.include_router(alerts.router)
+router.include_router(users.router)

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -1,0 +1,125 @@
+"""
+User management endpoints.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, Header
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from pydantic import BaseModel
+import logging
+
+from app.core.database import get_db
+from app.core.auth import get_current_user_from_token
+from app.models.models import User
+
+router = APIRouter(prefix="/users", tags=["users"])
+logger = logging.getLogger(__name__)
+
+
+class LineTokenResponse(BaseModel):
+    line_notify_connected: bool
+
+
+class LineTokenUpdate(BaseModel):
+    line_notify_token: str
+
+
+class LineTokenTestResult(BaseModel):
+    success: bool
+    message: str
+
+
+async def get_current_user_id(authorization: str = Header(None)) -> str:
+    """Extract user ID from Authorization header."""
+    if not authorization:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    
+    user = await get_current_user_from_token(authorization)
+    if not user:
+        raise HTTPException(status_code=401, detail="Invalid token")
+    return user.id
+
+
+@router.get("/me/line-token", response_model=LineTokenResponse)
+async def get_line_token_status(
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(get_current_user_id)
+):
+    """Get LINE Notify token connection status."""
+    result = await db.execute(
+        select(User.line_notify_token).where(User.id == user_id)
+    )
+    token = result.scalar_one_or_none()
+    
+    return LineTokenResponse(line_notify_connected=bool(token))
+
+
+@router.put("/me/line-token", response_model=LineTokenResponse)
+async def update_line_token(
+    token_data: LineTokenUpdate,
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(get_current_user_id)
+):
+    """Update LINE Notify token for the current user."""
+    result = await db.execute(
+        select(User).where(User.id == user_id)
+    )
+    user = result.scalar_one_or_none()
+    
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    
+    user.line_notify_token = token_data.line_notify_token
+    await db.commit()
+    
+    logger.info(f"User {user_id} updated LINE Notify token")
+    
+    return LineTokenResponse(line_notify_connected=bool(token_data.line_notify_token))
+
+
+@router.delete("/me/line-token", response_model=LineTokenResponse)
+async def delete_line_token(
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(get_current_user_id)
+):
+    """Remove LINE Notify token (disconnect LINE notifications)."""
+    result = await db.execute(
+        select(User).where(User.id == user_id)
+    )
+    user = result.scalar_one_or_none()
+    
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    
+    user.line_notify_token = None
+    await db.commit()
+    
+    logger.info(f"User {user_id} disconnected LINE Notify")
+    
+    return LineTokenResponse(line_notify_connected=False)
+
+
+@router.post("/me/line-token/test", response_model=LineTokenTestResult)
+async def test_line_token(
+    token_data: LineTokenUpdate,
+    user_id: str = Depends(get_current_user_id)
+):
+    """Test LINE Notify token by sending a test message."""
+    from app.services.line_notify_service import send_line_notify
+    
+    test_message = """
+🔔 Stock Tracker LINE Notify Test
+
+Your LINE Notify integration is working! 
+You will receive stock alerts here.
+    """.strip()
+    
+    success = await send_line_notify(token_data.line_notify_token, test_message)
+    
+    if success:
+        return LineTokenTestResult(success=True, message="Test message sent! Check your LINE app.")
+    else:
+        return LineTokenTestResult(
+            success=False, 
+            message="Failed to send test message. Please check your LINE Notify token."
+        )

--- a/app/models/models.py
+++ b/app/models/models.py
@@ -30,6 +30,7 @@ class User(Base):
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
     )
+    line_notify_token: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
 
     # Relationships
     watchlists: Mapped[list["Watchlist"]] = relationship(

--- a/app/services/line_notify_service.py
+++ b/app/services/line_notify_service.py
@@ -1,0 +1,110 @@
+"""
+LINE Notify notification service.
+"""
+
+import httpx
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+import logging
+
+from app.models.models import User
+
+logger = logging.getLogger(__name__)
+
+LINE_NOTIFY_API = "https://notify-api.line.me/api/notify"
+
+
+async def send_line_notify(token: str, message: str) -> bool:
+    """
+    Send a notification via LINE Notify.
+    
+    Args:
+        token: LINE Notify token for the user
+        message: Message to send
+        
+    Returns:
+        True if successful, False otherwise
+    """
+    if not token:
+        logger.warning("LINE Notify token is empty")
+        return False
+    
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            response = await client.post(
+                LINE_NOTIFY_API,
+                headers={"Authorization": f"Bearer {token}"},
+                data={"message": message}
+            )
+            
+            if response.status_code == 200:
+                logger.info(f"LINE Notify sent successfully: {message[:50]}...")
+                return True
+            elif response.status_code == 401:
+                logger.error("LINE Notify token is invalid")
+                return False
+            elif response.status_code == 403:
+                logger.error("LINE Notify token does not have permission")
+                return False
+            else:
+                logger.error(f"LINE Notify API error: {response.status_code} - {response.text}")
+                return False
+                
+    except httpx.TimeoutException:
+        logger.error("LINE Notify API timeout")
+        return False
+    except httpx.RequestError as e:
+        logger.error(f"LINE Notify request error: {e}")
+        return False
+    except Exception as e:
+        logger.error(f"LINE Notify unexpected error: {e}")
+        return False
+
+
+async def notify_alert_triggered(
+    db: AsyncSession,
+    user_id: str,
+    symbol: str,
+    condition_type: str,
+    threshold: float,
+    current_price: float
+) -> bool:
+    """
+    Send LINE notification when an alert is triggered.
+    
+    Args:
+        db: Database session
+        user_id: User UUID
+        symbol: Stock symbol
+        condition_type: 'above', 'below', or 'change_pct'
+        threshold: Alert threshold value
+        current_price: Current stock price
+        
+    Returns:
+        True if notification sent successfully, False otherwise
+    """
+    # Get user's LINE Notify token
+    result = await db.execute(
+        select(User.line_notify_token).where(User.id == user_id)
+    )
+    token = result.scalar_one_or_none()
+    
+    if not token:
+        logger.debug(f"User {user_id} has no LINE Notify token configured")
+        return False
+    
+    # Format message
+    condition_text = {
+        "above": f"rose above ${threshold:.2f}",
+        "below": f"fell below ${threshold:.2f}",
+        "change_pct": f"changed by {threshold:+.2f}%"
+    }.get(condition_type, f"triggered at ${threshold:.2f}")
+    
+    message = f"""
+🚨 Stock Alert Triggered!
+
+{symbol}: ${current_price:.2f}
+Condition: {condition_text}
+    """.strip()
+    
+    return await send_line_notify(token, message)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import Dashboard from './pages/Dashboard'
 import Watchlist from './pages/Watchlist'
 import Alerts from './pages/Alerts'
 import StockSearch from './pages/StockSearch'
+import Settings from './pages/Settings'
 import Login from './pages/Login'
 import Signup from './pages/Signup'
 import './App.css'
@@ -20,6 +21,7 @@ function NavBar() {
         <li><NavLink to="/search" className={({ isActive }) => isActive ? 'active' : ''}>Search</NavLink></li>
         <li><NavLink to="/watchlist" className={({ isActive }) => isActive ? 'active' : ''}>Watchlist</NavLink></li>
         <li><NavLink to="/alerts" className={({ isActive }) => isActive ? 'active' : ''}>Alerts</NavLink></li>
+        <li><NavLink to="/settings" className={({ isActive }) => isActive ? 'active' : ''}>Settings</NavLink></li>
       </ul>
       <div className="nav-auth">
         {isAuthenticated ? (
@@ -58,6 +60,7 @@ function AppRoutes() {
       <Route path="/search" element={<RequireAuth><StockSearch /></RequireAuth>} />
       <Route path="/watchlist" element={<RequireAuth><Watchlist /></RequireAuth>} />
       <Route path="/alerts" element={<RequireAuth><Alerts /></RequireAuth>} />
+      <Route path="/settings" element={<RequireAuth><Settings /></RequireAuth>} />
     </Routes>
   )
 }

--- a/frontend/src/pages/Settings.css
+++ b/frontend/src/pages/Settings.css
@@ -1,0 +1,209 @@
+.settings-container {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 1.5rem;
+}
+
+.settings-container h2 {
+  color: white;
+  margin-bottom: 1.5rem;
+}
+
+.settings-section {
+  background: #1e1e3f;
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.settings-section h3 {
+  color: white;
+  margin-bottom: 1rem;
+  font-size: 1.1rem;
+}
+
+.settings-description {
+  color: #aaa;
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+}
+
+.settings-info p {
+  color: #ccc;
+  margin: 0.5rem 0;
+}
+
+.settings-info strong {
+  color: #4fc3f7;
+}
+
+/* LINE Notifications */
+.line-setup {
+  margin-top: 1rem;
+}
+
+.line-instructions {
+  background: #0d0d1a;
+  padding: 1rem;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+}
+
+.line-instructions h4 {
+  color: #4fc3f7;
+  font-size: 0.95rem;
+  margin-bottom: 0.75rem;
+}
+
+.line-instructions ol {
+  color: #aaa;
+  font-size: 0.85rem;
+  padding-left: 1.5rem;
+  margin: 0;
+}
+
+.line-instructions li {
+  margin: 0.4rem 0;
+}
+
+.line-instructions a {
+  color: #4fc3f7;
+}
+
+.line-instructions a:hover {
+  text-decoration: underline;
+}
+
+.line-token-input {
+  margin-bottom: 1rem;
+}
+
+.line-token-input label {
+  display: block;
+  color: #aaa;
+  font-size: 0.9rem;
+  margin-bottom: 0.4rem;
+}
+
+.line-token-input input {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid #333;
+  border-radius: 6px;
+  background: #0d0d1a;
+  color: white;
+  font-size: 0.95rem;
+  box-sizing: border-box;
+}
+
+.line-token-input input:focus {
+  outline: none;
+  border-color: #4fc3f7;
+}
+
+.line-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.btn-test {
+  padding: 0.6rem 1.2rem;
+  background: #333;
+  color: #ccc;
+  border: 1px solid #444;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.btn-test:hover:not(:disabled) {
+  background: #444;
+  color: white;
+}
+
+.btn-connect {
+  padding: 0.6rem 1.2rem;
+  background: #00b900;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.btn-connect:hover:not(:disabled) {
+  background: #00c900;
+}
+
+.btn-disconnect {
+  padding: 0.6rem 1.2rem;
+  background: transparent;
+  color: #ff6b6b;
+  border: 1px solid #ff6b6b;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.btn-disconnect:hover:not(:disabled) {
+  background: #ff6b6b;
+  color: white;
+}
+
+.line-connected {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: #0d0d1a;
+  padding: 1rem;
+  border-radius: 8px;
+}
+
+.line-status {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: #00c900;
+  font-weight: 500;
+}
+
+.line-status-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #666;
+}
+
+.line-status-dot.connected {
+  background: #00c900;
+  box-shadow: 0 0 8px #00c900;
+}
+
+.message {
+  padding: 0.75rem;
+  border-radius: 6px;
+  margin: 1rem 0;
+  font-size: 0.9rem;
+}
+
+.message.success {
+  background: rgba(0, 201, 0, 0.15);
+  color: #00c900;
+  border: 1px solid #00c900;
+}
+
+.message.error {
+  background: rgba(255, 107, 107, 0.15);
+  color: #ff6b6b;
+  border: 1px solid #ff6b6b;
+}
+
+.settings-loading {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 200px;
+  color: #4fc3f7;
+  font-size: 1.2rem;
+}

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,0 +1,180 @@
+import { useState, useEffect } from 'react'
+import { authService } from '../services/api'
+import { useAuth } from '../contexts/AuthContext'
+import './Settings.css'
+
+export default function Settings() {
+  const { user } = useAuth()
+  const [lineToken, setLineToken] = useState('')
+  const [lineConnected, setLineConnected] = useState(false)
+  const [isLoading, setIsLoading] = useState(true)
+  const [isSaving, setIsSaving] = useState(false)
+  const [isTesting, setIsTesting] = useState(false)
+  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null)
+
+  useEffect(() => {
+    loadLineStatus()
+  }, [])
+
+  const loadLineStatus = async () => {
+    try {
+      const status = await authService.getLineTokenStatus()
+      setLineConnected(status.line_notify_connected)
+    } catch (err) {
+      console.error('Failed to load LINE status:', err)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleSaveToken = async () => {
+    if (!lineToken.trim()) {
+      setMessage({ type: 'error', text: 'Please enter a LINE Notify token' })
+      return
+    }
+
+    setIsSaving(true)
+    setMessage(null)
+
+    try {
+      await authService.updateLineToken(lineToken.trim())
+      setLineConnected(true)
+      setLineToken('')
+      setMessage({ type: 'success', text: 'LINE Notify connected successfully!' })
+    } catch (err: any) {
+      setMessage({ type: 'error', text: err.response?.data?.detail || 'Failed to connect LINE Notify' })
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const handleTestToken = async () => {
+    if (!lineToken.trim()) {
+      setMessage({ type: 'error', text: 'Please enter a LINE Notify token first' })
+      return
+    }
+
+    setIsTesting(true)
+    setMessage(null)
+
+    try {
+      const result = await authService.testLineToken(lineToken.trim())
+      if (result.success) {
+        setMessage({ type: 'success', text: 'Test message sent! Check your LINE app.' })
+      } else {
+        setMessage({ type: 'error', text: result.message })
+      }
+    } catch (err: any) {
+      setMessage({ type: 'error', text: 'Failed to send test message' })
+    } finally {
+      setIsTesting(false)
+    }
+  }
+
+  const handleDisconnect = async () => {
+    setIsSaving(true)
+    setMessage(null)
+
+    try {
+      await authService.deleteLineToken()
+      setLineConnected(false)
+      setLineToken('')
+      setMessage({ type: 'success', text: 'LINE Notify disconnected.' })
+    } catch (err: any) {
+      setMessage({ type: 'error', text: 'Failed to disconnect LINE Notify' })
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  if (isLoading) {
+    return <div className="settings-loading">Loading...</div>
+  }
+
+  return (
+    <div className="settings-container">
+      <h2>Settings</h2>
+
+      <div className="settings-section">
+        <h3>Account</h3>
+        <div className="settings-info">
+          <p><strong>Username:</strong> {user?.username}</p>
+          <p><strong>Email:</strong> {user?.email}</p>
+        </div>
+      </div>
+
+      <div className="settings-section">
+        <h3>LINE Notifications</h3>
+        <p className="settings-description">
+          Connect LINE Notify to receive stock alerts directly in your LINE app.
+        </p>
+
+        {lineConnected ? (
+          <div className="line-connected">
+            <div className="line-status">
+              <span className="line-status-dot connected"></span>
+              <span>LINE Notify is connected</span>
+            </div>
+            <button
+              onClick={handleDisconnect}
+              disabled={isSaving}
+              className="btn-disconnect"
+            >
+              {isSaving ? 'Disconnecting...' : 'Disconnect'}
+            </button>
+          </div>
+        ) : (
+          <div className="line-setup">
+            <div className="line-instructions">
+              <h4>How to get your LINE Notify token:</h4>
+              <ol>
+                <li>Go to <a href="https://notify-bot.line.me/" target="_blank" rel="noopener noreferrer">LINE Notify</a></li>
+                <li>Sign in with your LINE account</li>
+                <li>Click "My page" in the menu</li>
+                <li>Scroll down to "Generate token"</li>
+                <li>Enter a token name (e.g., "Stock Tracker")</li>
+                <li>Select "1-on-1 chat with LINE Notify"</li>
+                <li>Click "Generate" and copy the token</li>
+              </ol>
+            </div>
+
+            <div className="line-token-input">
+              <label htmlFor="lineToken">LINE Notify Token</label>
+              <input
+                type="password"
+                id="lineToken"
+                value={lineToken}
+                onChange={(e) => setLineToken(e.target.value)}
+                placeholder="Paste your token here"
+                disabled={isSaving || isTesting}
+              />
+            </div>
+
+            {message && (
+              <div className={`message ${message.type}`}>
+                {message.text}
+              </div>
+            )}
+
+            <div className="line-actions">
+              <button
+                onClick={handleTestToken}
+                disabled={isSaving || isTesting || !lineToken.trim()}
+                className="btn-test"
+              >
+                {isTesting ? 'Sending...' : 'Test Token'}
+              </button>
+              <button
+                onClick={handleSaveToken}
+                disabled={isSaving || isTesting || !lineToken.trim()}
+                className="btn-connect"
+              >
+                {isSaving ? 'Connecting...' : 'Connect LINE Notify'}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -265,4 +265,24 @@ export const authService = {
     // Call logout endpoint and clear cookies
     apiClient.post('/auth/logout').catch(console.error)
   },
+
+  async getLineTokenStatus(): Promise<{ line_notify_connected: boolean }> {
+    const response = await apiClient.get('/users/me/line-token')
+    return response.data
+  },
+
+  async updateLineToken(token: string): Promise<{ line_notify_connected: boolean }> {
+    const response = await apiClient.put('/users/me/line-token', { line_notify_token: token })
+    return response.data
+  },
+
+  async deleteLineToken(): Promise<{ line_notify_connected: boolean }> {
+    const response = await apiClient.delete('/users/me/line-token')
+    return response.data
+  },
+
+  async testLineToken(token: string): Promise<{ success: boolean; message: string }> {
+    const response = await apiClient.post('/users/me/line-token/test', { line_notify_token: token })
+    return response.data
+  },
 }


### PR DESCRIPTION
## Summary
Implement LINE Notify integration so users can receive stock alerts via LINE Messaging API.

### Backend Changes
- Add  field to User model
- Create  for sending LINE Notify messages
- Add  API endpoints:
  -  - Check if LINE is connected
  -  - Connect LINE Notify token
  -  - Disconnect LINE Notify
  -  - Send test message
- Modify alert trigger to send LINE notification when triggered

### Frontend Changes
- Add Settings page with LINE Notify token management
- Add Settings link to navbar
- Add API methods for LINE token operations

### How Users Connect LINE
1. Go to LINE Notify (https://notify-bot.line.me/)
2. Generate a personal access token
3. Enter the token in Settings page
4. Test and save

### Testing
- [ ] Connect LINE Notify with test token
- [ ] Manually trigger an alert and verify LINE notification received
- [ ] Disconnect LINE Notify