### PR TITLE
fix: correct nginx.conf path in frontend Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -26,7 +26,7 @@ FROM nginx:alpine
 COPY --from=builder /app/dist /usr/share/nginx/html
 
 # Copy nginx config
-COPY frontend/nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 3000
 


### PR DESCRIPTION
## Summary
Docker build context is `./frontend`, so the COPY path should not include `frontend/` prefix.

## Fix
- `COPY frontend/nginx.conf` → `COPY nginx.conf`

## Root Cause
PR #117 (i18n) 引入的 Dockerfile 變更，使用了錯誤的路徑。