### PR TITLE
fix: use 'sub' claim in JWT payload

### DIFF
--- a/app/api/v1/portfolio/risk_analytics.py
+++ b/app/api/v1/portfolio/risk_analytics.py
@@ -54,7 +54,7 @@ def get_current_user_id(authorization: str = Header(...)) -> str:
     if not payload:
         raise HTTPException(status_code=401, detail="Invalid or expired token")
 
-    user_id = payload.get("user_id")
+    user_id = payload.get("sub")
     if not user_id:
         raise HTTPException(status_code=401, detail="Invalid token payload")
 


### PR DESCRIPTION
Fix JWT payload key: use 'sub' instead of 'user_id'