### PR TITLE
fix: register risk_analytics router in main router

### DIFF
--- a/app/api/v1/portfolio/__init__.py
+++ b/app/api/v1/portfolio/__init__.py
@@ -1,0 +1,4 @@
+# Portfolio package
+from app.api.v1.portfolio.risk_analytics import router as risk_analytics_router
+
+__all__ = ["risk_analytics_router"]

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -5,6 +5,7 @@ API v1 router.
 from fastapi import APIRouter
 
 from app.api.v1 import alerts, auth, stocks, watchlists, users, portfolio
+from app.api.v1.portfolio.risk_analytics import router as risk_analytics_router
 
 router = APIRouter(prefix="/api/v1")
 
@@ -14,3 +15,4 @@ router.include_router(watchlists.router)
 router.include_router(alerts.router)
 router.include_router(users.router)
 router.include_router(portfolio.router)
+router.include_router(risk_analytics_router)


### PR DESCRIPTION
## Fix
- Create app/api/v1/portfolio/__init__.py
- Import and include risk_analytics_router in router.py
- The risk_analytics endpoint was never registered in the main FastAPI app!