### PR TITLE
fix: use 'sub' claim in JWT payload for risk analytics endpoint

### DIFF
--- a/app/api/v1/portfolio.py
+++ b/app/api/v1/portfolio.py
@@ -660,7 +660,7 @@ async def get_portfolio_risk_analytics(
     if not payload or "user_id" not in payload:
         raise HTTPException(status_code=401, detail="Invalid or expired token")
 
-    user_id = payload["user_id"]
+    user_id = payload.get("sub")
 
     # Get user holdings
     result = await db.execute(

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -5,7 +5,6 @@ API v1 router.
 from fastapi import APIRouter
 
 from app.api.v1 import alerts, auth, stocks, watchlists, users, portfolio
-from app.api.v1.portfolio.risk_analytics import router as risk_analytics_router
 
 router = APIRouter(prefix="/api/v1")
 
@@ -15,4 +14,3 @@ router.include_router(watchlists.router)
 router.include_router(alerts.router)
 router.include_router(users.router)
 router.include_router(portfolio.router)
-router.include_router(risk_analytics_router)


### PR DESCRIPTION
## Fix Summary
- Change `payload['user_id']` to `payload.get('sub')` in portfolio.py risk-analytics endpoint
- Remove broken risk_analytics_router import from router.py (it was never registered due to module shadowing)

The risk_analytics router was never actually being used because portfolio.py (file) shadows portfolio/ (directory) in Python's import system. The actual endpoint is in portfolio.py.