### PR TITLE
fix: properly seed numpy.random for Monte Carlo reproducibility

### DIFF
--- a/app/services/monte_carlo_service.py
+++ b/app/services/monte_carlo_service.py
@@ -42,7 +42,11 @@ class MonteCarloService:
         Args:
             seed: Random seed for reproducibility in testing.
         """
-        self._rng = random.Random(seed) if seed is not None else random.Random()
+        if seed is not None:
+            self._rng = random.Random(seed)
+            np.random.seed(seed)
+        else:
+            self._rng = random.Random()
 
     def run_retirement_simulation(
         self, request: RetirementSimulationRequest


### PR DESCRIPTION
Fix test_retirement_simulation_reproducible_with_seed failing because numpy.random was not being seeded along with Python's random module.