### PR TITLE
Phase 26: Multi-language Expansion (ja/ko)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,17 +17,27 @@ const Portfolio = lazy(() => import('./pages/Portfolio'))
 const PortfolioSignals = lazy(() => import('./pages/PortfolioSignals'))
 const PortfolioHealth = lazy(() => import('./pages/PortfolioHealth'))
 
+const LANGUAGES = [
+  { code: 'en', label: 'EN', native: 'English' },
+  { code: 'zh-TW', label: '繁', native: '繁體中文' },
+  { code: 'ja', label: '日', native: '日本語' },
+  { code: 'ko', label: '한', native: '한국어' },
+]
+
 function LanguageSwitcher() {
   const { i18n } = useTranslation()
 
-  const toggleLanguage = () => {
-    const newLang = i18n.language === 'en' ? 'zh-TW' : 'en'
-    i18n.changeLanguage(newLang)
+  const currentLang = LANGUAGES.find(l => l.code === i18n.language) || LANGUAGES[0]
+
+  const cycleLanguage = () => {
+    const currentIndex = LANGUAGES.findIndex(l => l.code === i18n.language)
+    const nextIndex = (currentIndex + 1) % LANGUAGES.length
+    i18n.changeLanguage(LANGUAGES[nextIndex].code)
   }
 
   return (
-    <button onClick={toggleLanguage} className="btn-lang-switch" title="Toggle Language">
-      {i18n.language === 'en' ? '中文' : 'EN'}
+    <button onClick={cycleLanguage} className="btn-lang-switch" title={currentLang.native}>
+      {currentLang.label}
     </button>
   )
 }

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -4,10 +4,14 @@ import LanguageDetector from 'i18next-browser-languagedetector';
 
 import en from './locales/en.json';
 import zhTW from './locales/zh-TW.json';
+import ja from './locales/ja.json';
+import ko from './locales/ko.json';
 
 const resources = {
   en: { translation: en },
   'zh-TW': { translation: zhTW },
+  ja: { translation: ja },
+  ko: { translation: ko },
 };
 
 i18n
@@ -16,7 +20,7 @@ i18n
   .init({
     resources,
     fallbackLng: 'en',
-    supportedLngs: ['en', 'zh-TW'],
+    supportedLngs: ['en', 'zh-TW', 'ja', 'ko'],
     interpolation: {
       escapeValue: false,
     },

--- a/frontend/src/locales/ja.json
+++ b/frontend/src/locales/ja.json
@@ -1,0 +1,108 @@
+{
+  "nav": {
+    "dashboard": "ダッシュボード",
+    "watchlist": "ウォッチリスト",
+    "alerts": "アラート",
+    "portfolio": "ポートフォリオ",
+    "retirement": "退職シミュレーション",
+    "settings": "設定",
+    "logout": "ログアウト"
+  },
+  "dashboard": {
+    "title": "ダッシュボード",
+    "totalValue": "総資産",
+    "dayChange": "前日比",
+    "stocks": "株式",
+    "etfs": "ETF",
+    "bonds": "債券",
+    "aiSignals": "AIシグナル",
+    "signal": "シグナル",
+    "confidence": "信頼度",
+    "price": "価格",
+    "change": "変動",
+    "buy": "買い",
+    "sell": "売り",
+    "hold": "保有"
+  },
+  "watchlist": {
+    "title": "ウォッチリスト",
+    "addSymbol": "銘柄を追加",
+    "symbol": "銘柄コード",
+    "price": "価格",
+    "change": "変動",
+    "actions": "操作",
+    "delete": "削除",
+    "noItems": "ウォッチリストは空です"
+  },
+  "alerts": {
+    "title": "価格アラート",
+    "create": "アラート作成",
+    "symbol": "銘柄コード",
+    "condition": "条件",
+    "targetPrice": "目標価格",
+    "currentPrice": "現在価格",
+    "status": "ステータス",
+    "active": "有効",
+    "triggered": "発動済",
+    "delete": "削除",
+    "noAlerts": "アラートは設定されていません"
+  },
+  "portfolio": {
+    "title": "ポートフォリオ概要",
+    "holdings": "保有銘柄",
+    "totalValue": "総資産",
+    "totalGain": "総損益",
+    "sector": "業種",
+    "assetType": "資産タイプ",
+    "quantity": "数量",
+    "avgCost": "平均取得単価",
+    "currentPrice": "現在価格",
+    "gainLoss": "損益",
+    "aiSignal": "AIシグナル",
+    "exportPdf": "PDF出力",
+    "noHoldings": "保有銘柄がありません"
+  },
+  "settings": {
+    "title": "設定",
+    "account": "アカウント",
+    "discord": "Discord通知",
+    "discordWebhook": "Discord Webhook URL",
+    "testWebhook": "テスト",
+    "save": "保存",
+    "delete": "削除",
+    "language": "言語"
+  },
+  "common": {
+    "loading": "読み込み中...",
+    "error": "エラーが発生しました",
+    "retry": "再試行",
+    "save": "保存",
+    "cancel": "キャンセル",
+    "confirm": "確認",
+    "delete": "削除",
+    "edit": "編集",
+    "add": "追加",
+    "close": "閉じる",
+    "search": "検索"
+  },
+  "auth": {
+    "login": "ログイン",
+    "logout": "ログアウト",
+    "email": "メールアドレス",
+    "password": "パスワード",
+    "welcome": "おかえりなさい"
+  },
+  "retirement": {
+    "title": "モンテカルロ退職シミュレーター",
+    "formTitle": "シミュレーションパラメータ",
+    "resultsTitle": "シミュレーション結果",
+    "currentAge": "現在の年齢",
+    "retirementAge": "目標退職年齢",
+    "currentSavings": "現在のポートフォリオ価値 ($)",
+    "monthlyContribution": "毎月の積立金額 ($)",
+    "desiredIncome": "退職後希望月収 ($)",
+    "riskProfile": "リスク許容度",
+    "portfolioAllocation": "ポートフォリオ配分 (%)",
+    "numSimulations": "シミュレーション回数"
+  }
+}

--- a/frontend/src/locales/ko.json
+++ b/frontend/src/locales/ko.json
@@ -1,0 +1,108 @@
+{
+  "nav": {
+    "dashboard": "대시보드",
+    "watchlist": "관심종목",
+    "alerts": "알림",
+    "portfolio": "포트폴리오",
+    "retirement": "퇴직 시뮬레이션",
+    "settings": "설정",
+    "logout": "로그아웃"
+  },
+  "dashboard": {
+    "title": "대시보드",
+    "totalValue": "총 자산",
+    "dayChange": "일일 변동",
+    "stocks": "주식",
+    "etfs": "ETF",
+    "bonds": "채권",
+    "aiSignals": "AI 시그널",
+    "signal": "시그널",
+    "confidence": "신뢰도",
+    "price": "가격",
+    "change": "변동",
+    "buy": "매수",
+    "sell": "매도",
+    "hold": "보유"
+  },
+  "watchlist": {
+    "title": "관심종목",
+    "addSymbol": "종목 추가",
+    "symbol": "종목코드",
+    "price": "가격",
+    "change": "변동",
+    "actions": "작업",
+    "delete": "삭제",
+    "noItems": "관심종목이 없습니다"
+  },
+  "alerts": {
+    "title": "가격 알림",
+    "create": "알림 생성",
+    "symbol": "종목코드",
+    "condition": "조건",
+    "targetPrice": "목표 가격",
+    "currentPrice": "현재 가격",
+    "status": "상태",
+    "active": "활성",
+    "triggered": "발동됨",
+    "delete": "삭제",
+    "noAlerts": "설정된 알림이 없습니다"
+  },
+  "portfolio": {
+    "title": "포트폴리오 개요",
+    "holdings": "보유 종목",
+    "totalValue": "총 자산",
+    "totalGain": "총 손익",
+    "sector": "섹터",
+    "assetType": "자산 유형",
+    "quantity": "수량",
+    "avgCost": "평균 매입단가",
+    "currentPrice": "현재 가격",
+    "gainLoss": "손익",
+    "aiSignal": "AI 시그널",
+    "exportPdf": "PDF 내보내기",
+    "noHoldings": "보유 종목이 없습니다"
+  },
+  "settings": {
+    "title": "설정",
+    "account": "계정",
+    "discord": "Discord 알림",
+    "discordWebhook": "Discord Webhook URL",
+    "testWebhook": "테스트",
+    "save": "저장",
+    "delete": "삭제",
+    "language": "언어"
+  },
+  "common": {
+    "loading": "로딩 중...",
+    "error": "오류가 발생했습니다",
+    "retry": "재시도",
+    "save": "저장",
+    "cancel": "취소",
+    "confirm": "확인",
+    "delete": "삭제",
+    "edit": "편집",
+    "add": "추가",
+    "close": "닫기",
+    "search": "검색"
+  },
+  "auth": {
+    "login": "로그인",
+    "logout": "로그아웃",
+    "email": "이메일",
+    "password": "비밀번호",
+    "welcome": "돌아오신 것을 환영합니다"
+  },
+  "retirement": {
+    "title": "몬테카를로 퇴직 시뮬레이터",
+    "formTitle": "시뮬레이션 매개변수",
+    "resultsTitle": "시뮬레이션 결과",
+    "currentAge": "현재 나이",
+    "retirementAge": "목표 퇴직 나이",
+    "currentSavings": "현재 포트폴리오 가치 ($)",
+    "monthlyContribution": "월 투자 금액 ($)",
+    "desiredIncome": "퇴직 후 희망 월 수입 ($)",
+    "riskProfile": "위험 허용범위",
+    "portfolioAllocation": "포트폴리오 배분 (%)",
+    "numSimulations": "시뮬레이션 횟수"
+  }
+}


### PR DESCRIPTION
## Phase 26: Multi-language Expansion (Japanese & Korean)

### Summary
Extends the existing i18n framework (Phase 7-05) to support Japanese and Korean languages.

### Changes
- **New**:  - Full Japanese translations
- **New**:  - Full Korean translations  
- **Modified**:  - Added ja/ko to supported languages
- **Modified**:  - Updated LanguageSwitcher to cycle through 4 languages (EN → 繁 → 日 → 한)

### Language Support
| Code | Language | Native Name |
|------|----------|-------------|
| en | English | English |
| zh-TW | Traditional Chinese | 繁體中文 |
| ja | Japanese | 日本語 |
| ko | Korean | 한국어 |

### Testing
- [ ] Verify language switcher cycles through all 4 languages
- [ ] Verify all UI text renders correctly in each language
- [ ] Verify language preference persists in localStorage
- [ ] CI tests pass

### Related Issues
- Issue #183: Phase 26: Multi-language Expansion (日本語/한국어)