### PR TITLE
feat: 交易歷史詳細檢視 (Transaction History Detail View) #203

### DIFF
--- a/frontend/src/components/SimulatedTrading.css
+++ b/frontend/src/components/SimulatedTrading.css
@@ -318,6 +318,159 @@
   color: #64748b;
 }
 
+/* ─── Trade History Detail View ─── */
+.trades-section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.trade-stats {
+  display: flex;
+  gap: 12px;
+  font-size: 12px;
+  color: #94a3b8;
+}
+
+.trade-stats span {
+  padding: 2px 8px;
+  background: #1a1a2e;
+  border-radius: 4px;
+}
+
+.pnl-positive { color: #10b981 !important; }
+.pnl-negative { color: #ef4444 !important; }
+
+.trades-controls {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+.trade-filters {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.trade-filters label {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 12px;
+  color: #94a3b8;
+}
+
+.trade-filters select,
+.trade-filters input {
+  padding: 5px 8px;
+  border-radius: 4px;
+  border: 1px solid #4a5568;
+  background: #1a1a2e;
+  color: #e2e8f0;
+  font-size: 12px;
+}
+
+.trade-filters input {
+  width: 100px;
+}
+
+.trade-sorts {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: #94a3b8;
+}
+
+.sort-btn {
+  padding: 4px 8px;
+  border-radius: 4px;
+  border: 1px solid #4a5568;
+  background: transparent;
+  color: #94a3b8;
+  cursor: pointer;
+  font-size: 12px;
+  transition: all 0.15s;
+}
+
+.sort-btn:hover,
+.sort-btn.active {
+  background: #4a5568;
+  color: #e2e8f0;
+}
+
+.btn-export {
+  padding: 4px 10px;
+  border-radius: 4px;
+  border: none;
+  background: #4a5568;
+  color: #e2e8f0;
+  cursor: pointer;
+  font-size: 12px;
+  transition: background 0.15s;
+}
+
+.btn-export:hover {
+  background: #5a6578;
+}
+
+.trades-empty {
+  text-align: center;
+  padding: 20px;
+  color: #64748b;
+  font-size: 14px;
+}
+
+.trade-item {
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.trade-item:hover {
+  background: #374151;
+}
+
+.trade-item.expanded {
+  background: #374151;
+}
+
+.trade-expand-hint {
+  font-size: 10px;
+  color: #64748b;
+  margin-left: auto;
+}
+
+.trade-expanded {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid #4a5568;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.trade-expanded-row {
+  display: flex;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.trade-expanded-label {
+  color: #64748b;
+  min-width: 60px;
+}
+
+.trade-expanded-row span:last-child {
+  color: #e2e8f0;
+}
+
 @media (max-width: 768px) {
   .config-row {
     grid-template-columns: 1fr;
@@ -329,5 +482,23 @@
 
   .result-card.large {
     grid-column: 1 / -1;
+  }
+
+  .trades-section-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .trades-controls {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .trade-filters {
+    width: 100%;
+  }
+
+  .trade-filters input {
+    width: 80px;
   }
 }

--- a/frontend/src/components/SimulatedTrading.tsx
+++ b/frontend/src/components/SimulatedTrading.tsx
@@ -1,8 +1,19 @@
-import { useState } from 'react'
+import { useState, useMemo } from 'react'
 import axios from 'axios'
 import './SimulatedTrading.css'
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api/v1'
+
+interface Trade {
+  id: string
+  timestamp: string
+  symbol: string
+  action: 'BUY' | 'SELL'
+  shares: number
+  price: number
+  total: number
+  reason: string
+}
 
 interface SimulationResult {
   initial_capital: number
@@ -13,16 +24,7 @@ interface SimulationResult {
   winning_trades: number
   losing_trades: number
   win_rate: number
-  trades: Array<{
-    id: string
-    timestamp: string
-    symbol: string
-    action: string
-    shares: number
-    price: number
-    total: number
-    reason: string
-  }>
+  trades: Trade[]
 }
 
 interface EvaluateResult {
@@ -36,6 +38,9 @@ interface EvaluateResult {
   bearish_factors: string[]
 }
 
+type SortField = 'timestamp' | 'total' | 'symbol'
+type SortDir = 'asc' | 'desc'
+
 function SimulatedTrading() {
   const [initialCapital, setInitialCapital] = useState(5000)
   const [duration, setDuration] = useState(30)
@@ -45,6 +50,111 @@ function SimulatedTrading() {
   const [evaluations, setEvaluations] = useState<EvaluateResult[] | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+
+  // Trade history detail state
+  const [filterAction, setFilterAction] = useState<'ALL' | 'BUY' | 'SELL'>('ALL')
+  const [filterSymbol, setFilterSymbol] = useState('')
+  const [sortField, setSortField] = useState<SortField>('timestamp')
+  const [sortDir, setSortDir] = useState<SortDir>('desc')
+  const [expandedTradeId, setExpandedTradeId] = useState<string | null>(null)
+
+  // Pair BUY and SELL trades to calculate P&L and holding period
+  const pairedTrades = useMemo(() => {
+    if (!result) return []
+    const buyMap = new Map<string, Trade>()
+    const pairs: Array<{
+      buy: Trade
+      sell: Trade
+      holdingDays: number
+      pnl: number
+      pnlPercent: number
+    }> = []
+
+    for (const trade of result.trades) {
+      if (trade.action === 'BUY') {
+        buyMap.set(trade.symbol, trade)
+      } else if (trade.action === 'SELL') {
+        const buy = buyMap.get(trade.symbol)
+        if (buy) {
+          const buyDate = new Date(buy.timestamp)
+          const sellDate = new Date(trade.timestamp)
+          const holdingMs = sellDate.getTime() - buyDate.getTime()
+          const holdingDays = Math.round(holdingMs / (1000 * 60 * 60 * 24))
+          const pnl = trade.total - buy.total
+          const pnlPercent = (pnl / buy.total) * 100
+          pairs.push({ buy, sell: trade, holdingDays, pnl, pnlPercent })
+          buyMap.delete(trade.symbol)
+        }
+      }
+    }
+    return pairs
+  }, [result])
+
+  // Build trade summary for display (interleaved with pairs)
+  const displayTrades = useMemo(() => {
+    if (!result) return []
+    let trades = [...result.trades]
+
+    // Filter
+    if (filterAction !== 'ALL') {
+      trades = trades.filter(t => t.action === filterAction)
+    }
+    if (filterSymbol.trim()) {
+      trades = trades.filter(t => t.symbol.toLowerCase().includes(filterSymbol.toLowerCase()))
+    }
+
+    // Sort
+    trades.sort((a, b) => {
+      let cmp = 0
+      if (sortField === 'timestamp') {
+        cmp = new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+      } else if (sortField === 'total') {
+        cmp = a.total - b.total
+      } else if (sortField === 'symbol') {
+        cmp = a.symbol.localeCompare(b.symbol)
+      }
+      return sortDir === 'asc' ? cmp : -cmp
+    })
+
+    return trades
+  }, [result, filterAction, filterSymbol, sortField, sortDir])
+
+  // Trade summary stats
+  const tradeStats = useMemo(() => {
+    if (!result) return null
+    const buys = result.trades.filter(t => t.action === 'BUY').length
+    const sells = result.trades.filter(t => t.action === 'SELL').length
+    const avgHolding = pairedTrades.length > 0
+      ? Math.round(pairedTrades.reduce((sum, p) => sum + p.holdingDays, 0) / pairedTrades.length)
+      : 0
+    const totalPnl = pairedTrades.reduce((sum, p) => sum + p.pnl, 0)
+    return { buys, sells, avgHolding, totalPnl }
+  }, [result, pairedTrades])
+
+  const handleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortDir(d => d === 'asc' ? 'desc' : 'asc')
+    } else {
+      setSortField(field)
+      setSortDir('desc')
+    }
+  }
+
+  const exportCSV = () => {
+    if (!result) return
+    const headers = ['ID', 'Timestamp', 'Symbol', 'Action', 'Shares', 'Price', 'Total', 'Reason']
+    const rows = result.trades.map(t => [
+      t.id, t.timestamp, t.symbol, t.action, t.shares, t.price.toFixed(2), t.total.toFixed(2), t.reason
+    ])
+    const csv = [headers, ...rows].map(r => r.join(',')).join('\n')
+    const blob = new Blob([csv], { type: 'text/csv' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `trades_${new Date().toISOString().slice(0, 10)}.csv`
+    a.click()
+    URL.revokeObjectURL(url)
+  }
 
   const handleEvaluate = async () => {
     setLoading(true)
@@ -97,6 +207,13 @@ function SimulatedTrading() {
 
   const getSignalBadgeClass = (shouldBuy: boolean) => {
     return shouldBuy ? 'badge-buy' : 'badge-sell'
+  }
+
+  const formatDate = (ts: string) => {
+    return new Date(ts).toLocaleString('zh-TW', {
+      month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit'
+    })
   }
 
   return (
@@ -243,23 +360,137 @@ function SimulatedTrading() {
 
           {result.trades.length > 0 && (
             <div className="trades-section">
-              <h5>📜 交易歷史</h5>
-              <div className="trades-list">
-                {result.trades.map((trade) => (
-                  <div key={trade.id} className={`trade-item ${trade.action.toLowerCase()}`}>
-                    <div className="trade-action">
-                      <span className={`trade-badge ${trade.action.toLowerCase()}`}>
-                        {trade.action}
-                      </span>
-                      <span className="trade-symbol">{trade.symbol}</span>
-                    </div>
-                    <div className="trade-details">
-                      <span>{trade.shares} 股 @ ${trade.price.toFixed(2)}</span>
-                      <span className="trade-total">${trade.total.toFixed(2)}</span>
-                    </div>
-                    <div className="trade-reason">{trade.reason}</div>
+              <div className="trades-section-header">
+                <h5>📜 交易歷史</h5>
+                {tradeStats && (
+                  <div className="trade-stats">
+                    <span>買入 {tradeStats.buys}</span>
+                    <span>賣出 {tradeStats.sells}</span>
+                    <span>平均持有 {tradeStats.avgHolding} 天</span>
+                    <span className={tradeStats.totalPnl >= 0 ? 'pnl-positive' : 'pnl-negative'}>
+                      總損益 ${tradeStats.totalPnl.toFixed(2)}
+                    </span>
                   </div>
-                ))}
+                )}
+              </div>
+
+              {/* Filter & Sort Controls */}
+              <div className="trades-controls">
+                <div className="trade-filters">
+                  <label>
+                    動作
+                    <select value={filterAction} onChange={e => setFilterAction(e.target.value as any)}>
+                      <option value="ALL">全部</option>
+                      <option value="BUY">買入</option>
+                      <option value="SELL">賣出</option>
+                    </select>
+                  </label>
+                  <label>
+                    股票
+                    <input
+                      type="text"
+                      value={filterSymbol}
+                      onChange={e => setFilterSymbol(e.target.value)}
+                      placeholder="搜尋..."
+                    />
+                  </label>
+                </div>
+                <div className="trade-sorts">
+                  <span>排序:</span>
+                  <button
+                    className={`sort-btn ${sortField === 'timestamp' ? 'active' : ''}`}
+                    onClick={() => handleSort('timestamp')}
+                  >
+                    時間 {sortField === 'timestamp' && (sortDir === 'asc' ? '↑' : '↓')}
+                  </button>
+                  <button
+                    className={`sort-btn ${sortField === 'total' ? 'active' : ''}`}
+                    onClick={() => handleSort('total')}
+                  >
+                    金額 {sortField === 'total' && (sortDir === 'asc' ? '↑' : '↓')}
+                  </button>
+                  <button
+                    className={`sort-btn ${sortField === 'symbol' ? 'active' : ''}`}
+                    onClick={() => handleSort('symbol')}
+                  >
+                    股票 {sortField === 'symbol' && (sortDir === 'asc' ? '↑' : '↓')}
+                  </button>
+                  <button className="btn-export" onClick={exportCSV}>
+                    📥 匯出 CSV
+                  </button>
+                </div>
+              </div>
+
+              <div className="trades-list">
+                {displayTrades.length === 0 ? (
+                  <div className="trades-empty">沒有符合條件的交易</div>
+                ) : (
+                  displayTrades.map((trade) => {
+                    const isExpanded = expandedTradeId === trade.id
+                    // Find paired trade info
+                    const pair = pairedTrades.find(
+                      p => (p.buy.id === trade.id || p.sell.id === trade.id)
+                    )
+                    const isBuy = trade.action === 'BUY'
+                    const paired = isBuy ? pair?.sell : pair?.buy
+
+                    return (
+                      <div
+                        key={trade.id}
+                        className={`trade-item ${trade.action.toLowerCase()} ${isExpanded ? 'expanded' : ''}`}
+                        onClick={() => setExpandedTradeId(isExpanded ? null : trade.id)}
+                      >
+                        <div className="trade-main">
+                          <div className="trade-action">
+                            <span className={`trade-badge ${trade.action.toLowerCase()}`}>
+                              {trade.action}
+                            </span>
+                            <span className="trade-symbol">{trade.symbol}</span>
+                            {isExpanded && <span className="trade-expand-hint">▲ 收合</span>}
+                            {!isExpanded && <span className="trade-expand-hint">▼ 展開</span>}
+                          </div>
+                          <div className="trade-details">
+                            <span>{trade.shares} 股 @ ${trade.price.toFixed(2)}</span>
+                            <span className="trade-total">${trade.total.toFixed(2)}</span>
+                          </div>
+                        </div>
+
+                        {isExpanded && (
+                          <div className="trade-expanded">
+                            <div className="trade-expanded-row">
+                              <span className="trade-expanded-label">時間</span>
+                              <span>{formatDate(trade.timestamp)}</span>
+                            </div>
+                            <div className="trade-expanded-row">
+                              <span className="trade-expanded-label">原因</span>
+                              <span>{trade.reason}</span>
+                            </div>
+                            {pair && (
+                              <>
+                                <div className="trade-expanded-row">
+                                  <span className="trade-expanded-label">配對{isBuy ? '賣出' : '買入'}</span>
+                                  <span>
+                                    {paired?.symbol} · {paired?.shares} 股 @ ${Number(paired?.price).toFixed(2)}
+                                  </span>
+                                </div>
+                                <div className="trade-expanded-row">
+                                  <span className="trade-expanded-label">持有期間</span>
+                                  <span>{pair.holdingDays} 天</span>
+                                </div>
+                                <div className="trade-expanded-row">
+                                  <span className="trade-expanded-label">該筆損益</span>
+                                  <span className={pair.pnl >= 0 ? 'pnl-positive' : 'pnl-negative'}>
+                                    ${pair.pnl.toFixed(2)} ({pair.pnlPercent >= 0 ? '+' : ''}{pair.pnlPercent.toFixed(2)}%)
+                                  </span>
+                                </div>
+                              </>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                    )
+                  })
+                )}
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary

Implements task **#203 — 交易歷史詳細檢視** for Phase 6 of the AI 模擬交易系統.

## Changes

### 
- Added filter controls: action type (ALL/BUY/SELL) + symbol text search
- Added sort controls: timestamp, amount, symbol with asc/desc toggle
- Added expandable trade rows — click to expand and see:
  - Full timestamp
  - Trade reason
  - Paired trade (corresponding BUY or SELL)
  - Holding period in days
  - P&L with percentage for SELL trades
- Added trade summary stats bar (total buys, sells, avg holding, total P&L)
- Added CSV export button

### 
- New styles for expanded trade rows, filter/sort controls, export button
- Mobile responsive fixes for detail view

## Test

- [x] TypeScript compiles with no errors
- [ ] Tested on dev environment (need Hermes QA)
- [ ] CI passes

Closes #203