### PR TITLE
fix: remove duplicate AgentDashboard import in App.tsx

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,7 +18,6 @@ const PortfolioSignals = lazy(() => import('./pages/PortfolioSignals'))
 const PortfolioHealth = lazy(() => import('./pages/PortfolioHealth'))
 const AgentDashboard = lazy(() => import('./pages/agent/AgentDashboard'))
 const PortfolioOverview = lazy(() => import('./pages/PortfolioOverview'))
-const AgentDashboard = lazy(() => import('./pages/agent/AgentDashboard'))
 const PassiveIncomeDashboard = lazy(() => import('./pages/PassiveIncomeDashboard'))
 const DividendTracker = lazy(() => import('./pages/DividendTracker'))
 


### PR DESCRIPTION
## Summary
Fix TypeScript compilation error introduced in Phase 48:
- `src/App.tsx` line 19, 21: duplicate `AgentDashboard` import causing TS2451 error
- CI Build and Push Docker Images job fails due to this

## Fix
Remove duplicate lazy import of AgentDashboard.

## Testing
- [x] `npm run build` locally (if available)
- [ ] CI passes
- [ ] Docker image builds successfully