### PR TITLE
fix: correct FuturesContract import after duplicate removal

### DIFF
--- a/app/api/v1/futures_api.py
+++ b/app/api/v1/futures_api.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from app.core.database import get_db
-from app.models.futures import FuturesPosition, FuturesContract, FuturesPriceAlert
+from app.models.futures import FuturesPosition, FuturesPriceAlert
 from app.models.user import User
 
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -10,8 +10,8 @@ from app.models.passive_income import (
     PassiveIncomeSource,
 )
 from app.models.fixed_income import Bond, TermDeposit
-from app.models.commodities import CommodityPosition
-from app.models.futures import FuturesPosition, FuturesContract, FuturesPriceAlert
+from app.models.commodities import CommodityPosition, FuturesContract
+from app.models.futures import FuturesPosition, FuturesPriceAlert
 from app.models.esg import ControversyAlert, EsgScore, EsgTrend, ExclusionList
 from app.models.family import Entity, EntityAccount, EntityMember, FamilyMember
 


### PR DESCRIPTION
## Summary

The f51563c commit (`fix: remove duplicate FuturesContract from futures.py`) removed the duplicate `FuturesContract` from `futures.py`, but it **incorrectly updated** `app/models/__init__.py` to still import `FuturesContract` from `futures.py` — which no longer has it.

This caused CI test collection to fail with:

```
ImportError: cannot import name 'FuturesContract' from 'app.models.futures'
```

## Fix

1. **`app/models/__init__.py`**: Import `FuturesContract` from `app.models.commodities` (where it lives), not from `futures`
2. **`app/api/v1/futures_api.py`**: Removed unused `FuturesContract` import (was imported from `futures` but never used)

## Root Cause

The f51563c commit had an internal inconsistency:
- It removed `FuturesContract` from `futures.py`  
- It updated `__init__.py` to import `FuturesContract` from `futures` ← contradiction

## Testing

- CI test collection should now pass (no more ImportError on FuturesContract)