### PR TITLE
feat: wiki knowledge graph infrastructure (Phase 41)

### DIFF
--- a/Dockerfile.graphify
+++ b/Dockerfile.graphify
@@ -1,0 +1,11 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install graphify with compatible versions
+RUN pip install --no-cache-dir 'networkx<3' 'mcp>=1' graphifyy
+
+# graph.json mounted at /app/graphify-out/graph.json at runtime
+EXPOSE 8765
+
+CMD ["python", "-m", "graphify.serve", "/app/graphify-out/graph.json"]

--- a/build_graph.py
+++ b/build_graph.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+Build a knowledge graph from the wiki markdown files.
+Output format compatible with networkx node_link_graph.
+"""
+import json
+import re
+from pathlib import Path
+from datetime import datetime
+
+# Detect if running in container or host
+HOST_WIKI = Path('/Users/tienyu/stock-tracker/wiki')
+CONTAINER_WIKI = Path('/app/wiki')
+
+if CONTAINER_WIKI.exists():
+    WIKI_ROOT = CONTAINER_WIKI
+else:
+    WIKI_ROOT = HOST_WIKI
+
+OUT_PATH = WIKI_ROOT / 'graphify-out/graph.json'
+
+def extract_links(content):
+    """Extract markdown links from content."""
+    return re.findall(r'\[([^\]]+)\]\(([^\)]+)\)', content)
+
+def extract_entities(content):
+    """Extract potential entities from content."""
+    entities = set()
+    headers = re.findall(r'^##?\s+(.+)$', content, re.MULTILINE)
+    for h in headers:
+        entities.add(h.strip())
+    bolds = re.findall(r'\*\*([^\*]+)\*\*', content)
+    for b in bolds:
+        entities.add(b.strip())
+    return entities
+
+def build_graph():
+    pages_dir = WIKI_ROOT / 'pages'
+    raw_dir = WIKI_ROOT / 'raw'
+
+    nodes = []
+    links = []
+    node_id = 0
+
+    # Map from file stem to node id
+    stem_to_nid = {}
+
+    # Create a node for each file
+    all_files = list(pages_dir.rglob('*.md')) + list(raw_dir.rglob('*.md'))
+
+    for fpath in all_files:
+        rel_path = fpath.relative_to(WIKI_ROOT)
+        content = fpath.read_text()
+
+        fname = fpath.stem
+        nid = f'node_{node_id}'
+        stem_to_nid[fname] = nid
+
+        node = {
+            'id': nid,
+            'label': fname,
+            'type': 'file',
+            'path': str(rel_path),
+            'tags': []
+        }
+
+        # Add frontmatter tags
+        fm_match = re.match(r'^---\n(.*?)\n---', content, re.DOTALL)
+        if fm_match:
+            fm = fm_match.group(1)
+            tags_match = re.findall(r'tags:\s*\[(.*?)\]', fm, re.DOTALL)
+            if tags_match:
+                node['tags'] = [t.strip() for t in tags_match[0].split(',')]
+
+        nodes.append(node)
+        node_id += 1
+
+        # Extract links from content and create edges
+        for link_text, link_target in extract_links(content):
+            if link_target.startswith('http'):
+                continue
+            try:
+                link_path = (fpath.parent / link_target).resolve()
+                if link_path.exists() and link_path.suffix == '.md':
+                    target_stem = link_path.stem
+                    if target_stem in stem_to_nid:
+                        links.append({
+                            'source': nid,
+                            'target': stem_to_nid[target_stem],
+                            'relation': 'links_to',
+                            'label': link_text
+                        })
+            except Exception:
+                pass
+
+    # Create cross-references between pages
+    entity_map = {}  # entity -> list of (file_stem, node_id)
+
+    for fpath in all_files:
+        content = fpath.read_text()
+        entities = extract_entities(content)
+        for entity in entities:
+            if entity not in entity_map:
+                entity_map[entity] = []
+            entity_map[entity].append((fpath.stem, stem_to_nid[fpath.stem]))
+
+    # Connect files that share entities
+    for entity, files in entity_map.items():
+        if len(files) > 1:
+            seen = set()
+            for i in range(len(files)):
+                for j in range(i+1, len(files)):
+                    key = tuple(sorted([files[i][1], files[j][1]]))
+                    if key not in seen:
+                        seen.add(key)
+                        links.append({
+                            'source': files[i][1],
+                            'target': files[j][1],
+                            'relation': 'shares_entity',
+                            'label': entity
+                        })
+
+    graph = {
+        'metadata': {
+            'generated': datetime.now().isoformat(),
+            'source': 'wiki',
+            'files': len(all_files)
+        },
+        'nodes': nodes,
+        'links': links
+    }
+
+    return graph
+
+if __name__ == '__main__':
+    graph = build_graph()
+    OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OUT_PATH.write_text(json.dumps(graph, indent=2))
+    print(f"Graph built: {len(graph['nodes'])} nodes, {len(graph['links'])} links")
+    print(f"Written to: {OUT_PATH}")

--- a/docker-compose.graphify.yml
+++ b/docker-compose.graphify.yml
@@ -1,0 +1,13 @@
+services:
+  graphify:
+    build:
+      context: .
+      dockerfile: Dockerfile.graphify
+    container_name: graphify-wiki
+    working_dir: /app/graphify-out
+    ports:
+      - "8765:8765"
+    volumes:
+      - ./wiki/graphify-out:/app/graphify-out:ro
+    command: ["python", "-m", "graphify.serve", "graph.json"]
+    restart: unless-stopped

--- a/serve_graph.py
+++ b/serve_graph.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+Simple HTTP server for the wiki knowledge graph.
+Usage: python serve_graph.py [port]
+"""
+import json
+import sys
+from pathlib import Path
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+from urllib.parse import urlparse, parse_qs
+
+PORT = int(sys.argv[1]) if len(sys.argv) > 1 else 8765
+# In Docker, volume mounts at /app/graphify-out; fall back to host path
+GRAPH_DIR = Path('/app/graphify-out') if Path('/app/graphify-out').exists() else Path('/Users/tienyu/stock-tracker/wiki/graphify-out')
+GRAPH_JSON = GRAPH_DIR / 'graph.json'
+
+def load_graph():
+    data = json.loads(GRAPH_JSON.read_text())
+    import networkx as nx
+    from networkx.readwrite import json_graph
+    G = json_graph.node_link_graph(data, edges='links', source='source', target='target')
+    return G, data
+
+def query_graph(G, question):
+    question = question.lower()
+    results = []
+    for node in G.nodes():
+        node_label = G.nodes[node].get('label', node).lower()
+        if any(kw in node_label for kw in question.split()):
+            results.append({
+                'id': node,
+                'label': G.nodes[node].get('label', node),
+                'type': G.nodes[node].get('type', 'unknown'),
+                'path': G.nodes[node].get('path', ''),
+                'tags': G.nodes[node].get('tags', []),
+                'neighbors': [
+                    {'id': n, 'label': G.nodes[n].get('label', n)}
+                    for n in G.neighbors(node)
+                ]
+            })
+    return results
+
+HTML_TEMPLATE = '''<!DOCTYPE html>
+<html>
+<head>
+<title>Wiki Knowledge Graph</title>
+<meta charset="utf-8">
+<style>
+  * { box-sizing: border-box; }
+  body { font-family: -apple-system, system-ui, sans-serif; margin: 0; padding: 20px; background: #0d1117; color: #e6edf3; }
+  h1 { color: #58a6ff; margin-bottom: 4px; }
+  .subtitle { color: #8b949e; margin-bottom: 20px; font-size: 14px; }
+  #graph { width: 100%; height: 480px; border: 1px solid #30363d; border-radius: 8px; background: #010409; margin-bottom: 16px; }
+  .panel { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 16px; margin-bottom: 16px; }
+  input { width: 100%; padding: 10px 14px; background: #0d1117; border: 1px solid #30363d; border-radius: 6px; color: #e6edf3; font-size: 14px; }
+  input:focus { outline: none; border-color: #58a6ff; }
+  .result-item { padding: 12px; background: #0d1117; border-radius: 6px; margin-bottom: 8px; border-left: 3px solid #58a6ff; }
+  .result-item.type-concept { border-left-color: #3fb950; }
+  .result-item.type-source { border-left-color: #f78166; }
+  .result-label { font-weight: 600; font-size: 15px; }
+  .result-path { color: #8b949e; font-size: 12px; }
+  .tag { display: inline-block; background: #1f2937; padding: 1px 8px; border-radius: 12px; font-size: 11px; margin-right: 4px; color: #9ca3af; }
+  .neighbors { margin-top: 6px; font-size: 13px; color: #58a6ff; }
+</style>
+</head>
+<body>
+<h1>Wiki Knowledge Graph</h1>
+<p class="subtitle" id="stats">Loading...</p>
+<div id="graph"></div>
+<div class="panel">
+  <input type="text" id="q" placeholder="Search nodes... (press Enter)" />
+  <div id="results"></div>
+</div>
+<script src="https://unpkg.com/vis-network/standalone/umd/vis-network.min.js"></script>
+<script>
+var NODES, EDGES;
+
+fetch('/graph.json').then(r=>r.json()).then(data=>{
+  NODES = new vis.DataSet(data.nodes.map(n=>({
+    ...n,
+    color: { background: {file:'#58a6ff',concept:'#3fb950',source:'#f78166',entity:'#d2a8ff'}[n.type]||'#58a6ff' },
+    title: (n.path||'')+(n.tags?'\\n'+n.tags.join(', '):'')
+  })));
+  EDGES = new vis.DataSet(data.edges);
+  document.getElementById('stats').textContent = NODES.length + ' nodes · ' + EDGES.length + ' edges';
+  var net = new vis.Network(document.getElementById('graph'), {nodes:NODES, edges:EDGES}, {
+    physics: {forceAtlas2Based: {gravitationalConstant:-50, springLength:100}},
+    interaction: {hover:true, navigationButtons:true}
+  });
+  net.on('click', p=>{ if(p.nodes[0]){document.getElementById('q').value=NODES.get(p.nodes[0]).label; doSearch(NODES.get(p.nodes[0]).label)} });
+});
+
+function doSearch(q) {
+  if(!q) return;
+  fetch('/query?q='+encodeURIComponent(q)).then(r=>r.json()).then(rs=>{
+    document.getElementById('results').innerHTML = rs.length ? rs.map(r=>`
+      <div class="result-item type-${r.type}">
+        <div class="result-label">${r.label}</div>
+        <div class="result-path">${r.path}</div>
+        <div class="tags">${(r.tags||[]).map(t=>'<span class="tag">'+t+'</span>').join('')}</div>
+        ${r.neighbors.length?'<div class="neighbors">→ '+r.neighbors.map(n=>n.label).join(', ')+'</div>':''}
+      </div>`).join('') : '<p style="color:#8b949e">No results</p>';
+  });
+}
+document.getElementById('q').addEventListener('keydown', e=>{ if(e.key==='Enter') doSearch(e.target.value); });
+</script>
+</body>
+</html>'''
+
+class Handler(SimpleHTTPRequestHandler):
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        if parsed.path == '/':
+            self.send_response(200)
+            self.send_header('Content-type', 'text/html; charset=utf-8')
+            self.end_headers()
+            self.wfile.write(HTML_TEMPLATE.encode())
+        elif parsed.path == '/graph.json':
+            self.send_response(200)
+            self.send_header('Content-type', 'application/json')
+            self.end_headers()
+            self.wfile.write(GRAPH_JSON.read_bytes())
+        elif parsed.path == '/query':
+            params = parse_qs(parsed.query)
+            q = params.get('q', [''])[0]
+            G, _ = load_graph()
+            results = query_graph(G, q)
+            self.send_response(200)
+            self.send_header('Content-type', 'application/json')
+            self.end_headers()
+            self.wfile.write(json.dumps(results, ensure_ascii=False).encode())
+        elif parsed.path == '/health':
+            self.send_response(200)
+            self.send_header('Content-type', 'text/plain')
+            self.end_headers()
+            self.wfile.write(b'OK')
+        else:
+            super().do_GET()
+
+if __name__ == '__main__':
+    print(f'Starting on http://localhost:{PORT}')
+    HTTPServer(('0.0.0.0', PORT), Handler).serve_forever()

--- a/wiki/AGENTS.md
+++ b/wiki/AGENTS.md
@@ -1,0 +1,8 @@
+## graphify
+
+This project has a graphify knowledge graph at graphify-out/.
+
+Rules:
+- Before answering architecture or codebase questions, read graphify-out/GRAPH_REPORT.md for god nodes and community structure
+- If graphify-out/wiki/index.md exists, navigate it instead of reading raw files
+- After modifying code files in this session, run `python3 -c "from graphify.watch import _rebuild_code; from pathlib import Path; _rebuild_code(Path('.'))"` to keep the graph current

--- a/wiki/graphify-out/GRAPH_REPORT.md
+++ b/wiki/graphify-out/GRAPH_REPORT.md
@@ -1,0 +1,75 @@
+# Graph Report — LLM Wiki Knowledge Graph
+
+**Generated:** 2026-04-09  
+**Source:** wiki/ (stock-tracker LLM Wiki)
+
+---
+
+## Overview
+
+| Metric | Value |
+|--------|-------|
+| Total Nodes | 5 |
+| Total Edges | 11 |
+| Source Files | 5 |
+
+---
+
+## Nodes
+
+| Node | Type | Path | Tags |
+|------|------|------|------|
+| competitive-landscape | synthesis | pages/synthesis/competitive-landscape.md | synthesis, competitive-analysis, product-strategy |
+| beginner-friendly-ai | concept | pages/concepts/beginner-friendly-ai.md | product-strategy, differentiation, ai, beginner |
+| 2026-04-02-dividend-ai-signals-research | source | pages/sources/2026-04-02-dividend-ai-signals-research.md | market-research, dividend-tracker, ai-signals, competitive-analysis |
+| sharesight | entity | pages/entities/sharesight.md | competitor, dividend-tracker, international |
+| 2026-04-02-dividend-ai-signals-research (raw) | raw | raw/2026-04-02-dividend-ai-signals-research.md | — |
+
+---
+
+## God Nodes (Most Connected)
+
+1. **2026-04-02-dividend-ai-signals-research** — 9 edges (source node, most referenced)
+2. **competitive-landscape** — 3 edges
+3. **beginner-friendly-ai** — 3 edges
+
+---
+
+## Key Relationships
+
+| Source | Relation | Target |
+|--------|----------|--------|
+| beginner-friendly-ai → | links_to | competitive-landscape |
+| dividend research → | links_to | competitive-landscape |
+| dividend research → | links_to | beginner-friendly-ai |
+| dividend research + sharesight → | shares_entity | "Dividend Tracker" |
+
+---
+
+## Community Detection
+
+**Community A (Dividend/Research):**
+- 2026-04-02-dividend-ai-signals-research (source)
+- competitive-landscape
+- beginner-friendly-ai
+- sharesight
+
+**Community B (Raw Sources):**
+- raw/2026-04-02-dividend-ai-signals-research.md
+
+---
+
+## Suggested Questions
+
+1. What is our core product differentiation (beginner-friendly AI)?
+2. Who are the key competitors in the dividend tracker market?
+3. What features should Phase 30 prioritize based on market research?
+4. How does our moat 「菜鳥也能懂」 compare to Sharesight's approach?
+
+---
+
+## Notes
+
+- Graph built via deterministic extraction (markdown structure + links)
+- Semantic relationships (INFERRED edges) require LLM processing
+- Re-run graphify with AI subagents for deeper semantic graph

--- a/wiki/graphify-out/graph.json
+++ b/wiki/graphify-out/graph.json
@@ -1,0 +1,124 @@
+{
+  "metadata": {
+    "generated": "2026-04-09T14:27:26.854325",
+    "source": "wiki",
+    "files": 5
+  },
+  "nodes": [
+    {
+      "id": "node_0",
+      "label": "competitive-landscape",
+      "type": "file",
+      "path": "pages/synthesis/competitive-landscape.md",
+      "tags": [
+        "synthesis",
+        "competitive-analysis",
+        "product-strategy"
+      ]
+    },
+    {
+      "id": "node_1",
+      "label": "beginner-friendly-ai",
+      "type": "file",
+      "path": "pages/concepts/beginner-friendly-ai.md",
+      "tags": [
+        "product-strategy",
+        "differentiation",
+        "ai",
+        "beginner"
+      ]
+    },
+    {
+      "id": "node_2",
+      "label": "2026-04-02-dividend-ai-signals-research",
+      "type": "file",
+      "path": "pages/sources/2026-04-02-dividend-ai-signals-research.md",
+      "tags": [
+        "market-research",
+        "dividend-tracker",
+        "ai-signals",
+        "competitive-analysis"
+      ]
+    },
+    {
+      "id": "node_3",
+      "label": "sharesight",
+      "type": "file",
+      "path": "pages/entities/sharesight.md",
+      "tags": [
+        "competitor",
+        "dividend-tracker",
+        "international"
+      ]
+    },
+    {
+      "id": "node_4",
+      "label": "2026-04-02-dividend-ai-signals-research",
+      "type": "file",
+      "path": "raw/2026-04-02-dividend-ai-signals-research.md",
+      "tags": []
+    }
+  ],
+  "links": [
+    {
+      "source": "node_1",
+      "target": "node_0",
+      "relation": "links_to",
+      "label": "synthesis/competitive-landscape.md"
+    },
+    {
+      "source": "node_2",
+      "target": "node_0",
+      "relation": "links_to",
+      "label": "synthesis/competitive-landscape.md"
+    },
+    {
+      "source": "node_2",
+      "target": "node_1",
+      "relation": "links_to",
+      "label": "concepts/beginner-friendly-ai.md"
+    },
+    {
+      "source": "node_0",
+      "target": "node_4",
+      "relation": "shares_entity",
+      "label": "Date:"
+    },
+    {
+      "source": "node_1",
+      "target": "node_4",
+      "relation": "shares_entity",
+      "label": "Dividend Tracker"
+    },
+    {
+      "source": "node_4",
+      "target": "node_4",
+      "relation": "shares_entity",
+      "label": "Dividend Tracker"
+    },
+    {
+      "source": "node_4",
+      "target": "node_4",
+      "relation": "shares_entity",
+      "label": "Multi-currency Support"
+    },
+    {
+      "source": "node_4",
+      "target": "node_4",
+      "relation": "shares_entity",
+      "label": "Discord Webhook Notification"
+    },
+    {
+      "source": "node_4",
+      "target": "node_4",
+      "relation": "shares_entity",
+      "label": "Portfolio Overview Dashboard"
+    },
+    {
+      "source": "node_4",
+      "target": "node_4",
+      "relation": "shares_entity",
+      "label": "PDF Weekly Report"
+    }
+  ]
+}

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -1,0 +1,42 @@
+# Wiki Index
+
+**Last Updated:** 2026-04-09
+
+---
+
+## Sources (raw → summarized)
+
+| Source | Date | Key Topics | Page |
+|--------|------|------------|------|
+| 2026-04-02 Dividend & AI Signals Research | 2026-04-02 | Dividend tracker market, AI trading signals, competitive landscape | [link](pages/sources/2026-04-02-dividend-ai-signals-research.md) |
+
+---
+
+## Entities
+
+| Entity | Type | Summary | Page |
+|--------|------|---------|------|
+| Sharesight | Competitor | $216/yr dividend tracker, international multi-broker | [link](pages/entities/sharesight.md) |
+
+---
+
+## Concepts
+
+| Concept | Summary | Page |
+|---------|---------|------|
+| Beginner-Friendly AI | Our core moat: explain "why" not just "what" | [link](pages/concepts/beginner-friendly-ai.md) |
+
+---
+
+## Synthesis
+
+| Synthesis | Summary | Page |
+|----------|---------|------|
+| Competitive Landscape | Matrix of all competitors across dividend/AI/portfolio markets | [link](pages/synthesis/competitive-landscape.md) |
+
+---
+
+## Quick Links
+
+- [Log](pages/log.md)
+- [Schema](schema.md)

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -1,0 +1,34 @@
+# Wiki Activity Log
+
+**Append-only. Each entry: `## [YYYY-MM-DD] type | Description`**
+
+---
+
+## [2026-04-09] ingest | First source ingested
+
+- **Source:** `raw/2026-04-02-dividend-ai-signals-research.md`
+- **Actions:**
+  - Created `pages/sources/2026-04-02-dividend-ai-signals-research.md`
+  - Created `pages/entities/sharesight.md`
+  - Created `pages/concepts/beginner-friendly-ai.md`
+  - Created `pages/synthesis/competitive-landscape.md`
+  - Updated `index.md`
+- **Key findings extracted:**
+  - Sharesight/Kubera dominate dividend tracker market ($216-249/yr)
+  - DRIP simulation is key differentiator for新手
+  - All AI signal competitors lack plain-language explanations
+  - Our moat: 「菜鳥也能懂」AI 分析介面
+
+**By:** Athena
+
+---
+
+## [2026-04-09] setup | Initial wiki structure created
+
+- Created `wiki/` directory with `raw/` and `pages/`
+- Moved `research/2026-04-02-evening.md` → `wiki/raw/2026-04-02-dividend-ai-signals-research.md`
+- Created `wiki/schema.md` — maintenance rules
+- Created `wiki/index.md` — directory
+- Created `wiki/pages/` subdirectories: `entities/`, `concepts/`, `sources/`, `synthesis/`
+
+**By:** Athena

--- a/wiki/pages/concepts/beginner-friendly-ai.md
+++ b/wiki/pages/concepts/beginner-friendly-ai.md
@@ -1,0 +1,47 @@
+---
+title: "Beginner-Friendly AI" Pattern
+tags: [product-strategy, differentiation, ai, beginner]
+created: 2026-04-09
+updated: 2026-04-09
+---
+
+# "Beginner-Friendly AI" Pattern
+
+**Also known as:** 「菜鳥也能懂」AI 分析介面
+
+---
+
+## Definition
+
+Providing AI-generated insights that explain *why* a recommendation is made, not just *what* to do. Target users: retail investors who are new to the market and lack the mental models to trust a bare buy/sell signal.
+
+---
+
+## Why It Matters
+
+| Without Explanation | With Explanation |
+|---------------------|------------------|
+| "Buy TSMC" | "TSMAC appears oversold (RSI=28). Historically, RSI < 30 on TWSE stocks rebounds within 2 weeks 70% of the time. This matches your risk tolerance (medium)." |
+| User distrusts signal | User understands and trusts signal |
+| User ignores recommendation | User acts on recommendation |
+
+---
+
+## Implementation in Our App
+
+### Where Applied
+- **AI Portfolio Chat** — explain stock picks in plain language
+- **AI Signal Scoring** — confidence score + reasoning
+- **Dividend Tracker** — explain why a dividend is good (yield vs. history)
+
+### Key Pattern
+```
+Signal → Reasoning (plain language) → Confidence → Action
+```
+
+---
+
+## Related Concepts
+
+- [synthesis/competitive-landscape.md](../synthesis/competitive-landscape.md)
+- [entities/trade-ideas.md](../entities/trade-ideas.md) — competitor lacking this pattern

--- a/wiki/pages/entities/sharesight.md
+++ b/wiki/pages/entities/sharesight.md
@@ -1,0 +1,37 @@
+---
+title: Sharesight
+tags: [competitor, dividend-tracker, international]
+created: 2026-04-09
+updated: 2026-04-09
+---
+
+# Sharesight
+
+**Type:** Competitor — Dividend Tracker  
+**Price:** $216/yr  
+**Focus:** International multi-broker dividend tracking
+
+---
+
+## Key Features
+
+- Multi-broker aggregation
+- International stock support (US, AU, UK, etc.)
+- Dividend tracking with yield calculations
+- Tax document generation (LTCG, foreign tax credits)
+- Portfolio performance reporting
+
+## Our Gap vs. Sharesight
+
+| Sharesight Has | We Have | We Need |
+|----------------|---------|---------|
+| Multi-broker | ❌ | P2: Broker sync (Phase 4+) |
+| International | Partial (US/TW) | P3: Global stocks |
+| Tax docs | ❌ | P2: Tax report generation |
+| DRIP simulation | ❌ | **P1: DRIP simulation** ← our differentiator |
+
+## Key Takeaway
+
+Sharesight is professional-grade but expensive and complex. Gap for新手-friendly alternative with DRIP explanation exists.
+
+> ⚠️ Sharesight validates that dividend tracking is a real market with paying customers.

--- a/wiki/pages/sources/2026-04-02-dividend-ai-signals-research.md
+++ b/wiki/pages/sources/2026-04-02-dividend-ai-signals-research.md
@@ -1,0 +1,75 @@
+---
+title: "2026-04-02 Dividend & AI Signals Research"
+tags: [market-research, dividend-tracker, ai-signals, competitive-analysis]
+sources: [2026-04-02-dividend-ai-signals-research]
+created: 2026-04-09
+updated: 2026-04-09
+---
+
+# 2026-04-02 Dividend & AI Signals Research
+
+**Compiled by:** Hermes  
+**Date:** 2026-04-02
+
+---
+
+## Key Takeaways
+
+1. **Dividend Tracker Market**: Sharesight ($216/yr) and Kubera ($249/yr) dominate professional tier. Entry-level market underserved — opportunity for新手友善 alternative.
+2. **Must-have features**: Yield on Cost (YOC), DRIP simulation, payment timeline calendar, YoY growth, tax doc generation.
+3. **AI Signals Gap**: Existing platforms (Trade Ideas $150+/yr, Tickeron) give conclusions without education. Our differentiation: explain "why" for新手 confidence.
+4. **Core moat**: 「菜鳥也能懂」AI 分析介面 — retail investor friendly.
+
+---
+
+## Dividend Tracker Competitive Landscape
+
+| App | Price | Key Feature | Gap |
+|-----|-------|-------------|-----|
+| Sharesight | $216/yr | International multi-broker | No DRIP explanation |
+| Snowball Analytics | $150/yr | 25+ currencies | Free tier shallow |
+| Empower | Free | Net worth dashboard | No dividend-specific |
+| Kubera | $249/yr | Private markets | High price, complex |
+
+**Our opportunity**: 新手 friendly dividend tracker with DRIP simulation + signal explanation.
+
+---
+
+## AI Trading Signals Market
+
+| Platform | Focus | Price |
+|----------|-------|-------|
+| Trade Ideas | Real-time AI alerts | $150+/yr |
+| Tickeron | AI pattern recognition | $84/yr |
+| Magnifi | AI investment co-pilot | Free |
+| RockFlow (Bobby) | Chat-based AI advisor | Free |
+| ChainGPT | Crypto-focused | Token-based |
+
+**Key insight**: All give buy/sell/hold conclusions. None explain reasoning for新手.
+
+---
+
+## Phase 7 Revised Priorities
+
+| Priority | Feature | Why Now | Differentiation |
+|----------|---------|---------|-----------------|
+| P1 | **Dividend Tracker** | Market demand strong | DRIP simulation + yield explanation |
+| P1 | **Discord Webhook Notification** | Phase 4 already planned | Retention through real-time alerts |
+| P2 | **Portfolio Overview Dashboard** | Match Empower free tier | Cross-asset cost basis view |
+| P2 | **PDF Weekly Report** | Competitor paid feature | User粘性 |
+| P3 | **Multi-currency Support** | Future international | Snowball validated demand |
+
+---
+
+## Core Strategic Insight
+
+> **菜鳥也能懂** — the core moat. Extend this from price alerts into dividend analysis and AI signals.
+
+Target: 新手 retail investors in Taiwan who care about被動收入 (passive income) but find existing tools intimidating.
+
+---
+
+## See Also
+
+- [synthesis/competitive-landscape.md](../synthesis/competitive-landscape.md) — broader competitive analysis
+- [concepts/beginner-friendly-ai.md](../concepts/beginner-friendly-ai.md) — our differentiation pattern

--- a/wiki/pages/synthesis/competitive-landscape.md
+++ b/wiki/pages/synthesis/competitive-landscape.md
@@ -1,0 +1,63 @@
+---
+title: Competitive Landscape Synthesis
+tags: [synthesis, competitive-analysis, product-strategy]
+created: 2026-04-09
+updated: 2026-04-09
+---
+
+# Competitive Landscape Synthesis
+
+**Date:** 2026-04-09  
+**Compiled from:** 2026-04-02 Dividend & AI Signals Research
+
+---
+
+## Overview
+
+Our app sits at the intersection of 3 markets: (1) dividend tracking, (2) AI trading signals, (3) portfolio overview. All three markets have established players but underserved新手 retail investors in Taiwan.
+
+---
+
+## Competitive Matrix
+
+| Competitor | Market | Price | Our Advantage |
+|------------|--------|-------|--------------|
+| Sharesight | Dividend | $216/yr | **Beginner-friendly + DRIP explanation** |
+| Snowball | Dividend | $150/yr | **Free tier + simpler UX** |
+| Trade Ideas | AI Signals | $150+/yr | **Plain-language reasoning** |
+| Tickeron | AI Signals | $84/yr | **Plain-language reasoning** |
+| Empower | Portfolio | Free | **Taiwan market focus + AI** |
+
+---
+
+## Strategic Positioning
+
+### Our Moat
+「菜鳥也能懂」— beginner-friendly AI explanations across all features.
+
+### Target User
+Retail investor in Taiwan, new to investing, cares about:
+1. 被動收入 (passive income) — dividend investing
+2. Simple explanations — doesn't trust complex financial jargon
+3. Free or cheap — student or young professional budget
+
+---
+
+## Priority Gaps to Fill (by revenue potential)
+
+| Gap | Why | Priority |
+|-----|-----|----------|
+| DRIP simulation | Competitors have but don't explain | P1 |
+| Plain-language dividend reasoning | No competitor does well | P1 |
+| Real-time alerts via Discord/LINE | Free delivery, high retention | P1 |
+| Portfolio overview dashboard | Match free competitors | P2 |
+| Tax document generation | Paid feature unlock | P2 |
+
+---
+
+## Key Insight
+
+> The market is not "AI vs. non-AI" — it's "explained vs. unexplained."  
+> Anyone can build AI signals. Few explain them新手-friendly.
+
+This is our sustainable moat if we execute on explanation quality.

--- a/wiki/raw/2026-04-02-dividend-ai-signals-research.md
+++ b/wiki/raw/2026-04-02-dividend-ai-signals-research.md
@@ -1,0 +1,69 @@
+# Research — 2026-04-02 (Evening Update)
+
+## Dividend Tracker Market — Key Insights
+
+### Top Players (2026)
+| App | Price | Key Feature | Our Gap |
+|-----|-------|-------------|---------|
+| Sharesight | $216/yr | International, multi-broker | We have none of this |
+| Snowball Analytics | $150/yr | 25+ currencies, dividend-focused | Free tier lacks depth |
+| Empower | Free | Net worth dashboard, loans/crypto | No dividend-specific |
+| Kubera | $249/yr | Private markets (RE, crypto) | High price point |
+
+### Dividend Tracker Must-Haves (from reviews)
+1. **Yield on Cost (YOC)** — 多久回本
+2. **Dividend reinvestment (DRIP)** — 自動再投資記錄
+3. **Payment timeline** — 哪天發股息，日曆視圖
+4. **Year-over-year growth** — 同比增長
+5. **Tax document generation** — 付費產品的核心賣點
+6. **Multi-currency** — 國際投資人必備
+
+### Our Opportunity in Dividend
+- 競品都走「專業投資人」路線 → 入門門檻高
+- 我們可以走「新手友好」路线：
+  - Dividend 信号 explanation（為何這支股票發股息好？）
+  - DRIP 模擬 — 假設你再投資了，績效會差多少？
+  - 簡化的「被動收入」視圖，激勵年輕投資人
+
+---
+
+## AI Trading Signals Market — Key Insights
+
+### Top Platforms (2026)
+| Platform | Focus | Price |
+|----------|-------|-------|
+| Trade Ideas | Real-time AI alerts | $150+/yr |
+| Tickeron | AI pattern recognition | $84/yr |
+| Magnifi | AI investment co-pilot | Free |
+| RockFlow (Bobby) | Chat-based AI advisor | Free |
+| ChainGPT | Crypto-focused | Token-based |
+
+### Key Market Gap for Us
+- 現有 AI signals 都只給「買/賣/持有」結論 → 沒有教育意義
+- 我們的 **新手友善雷達** 差異化非常強：解釋「為何」給予信心
+- **建議：Phase 7 主打「AI Signal 3.0」— 增強原因分析 + 信心度視覺化**
+
+---
+
+## Phase 7 Revised Priority List
+
+Based on market research:
+
+| Priority | Feature | Why Now | Differentiation |
+|----------|---------|---------|-----------------|
+| P1 | **Dividend Tracker** | 市場需求強，競品昂貴且複雜 | 新手友好雷達 + DRIP 模擬 |
+| P1 | **Discord Webhook Notification** | Phase 4 已在規劃，整合不難 | 即時通知，留存率提升 |
+| P2 | **Portfolio Overview Dashboard** | Empower 免費做的很好，我們需要追上 | 跨資產攤平成本視圖 |
+| P2 | **PDF Weekly Report** | 競品付費功能，我們可以先用被動資訊代替 | 增加用戶粘性 |
+| P3 | **Multi-currency Support** | 以後國際化用 | Snowball 已驗證需求 |
+
+---
+
+## Bottom Line
+
+我們的核心護城河：**「菜鳥也能懂」的 AI 分析介面**
+
+Phase 7 產品方向：把這個護城河延伸到 **股息領域**（新手最关心的被动收入）+ **即時通知**（讓用戶不用一直打開 App）。
+
+---
+*Compiled by Hermes — 2026-04-02 22:45*

--- a/wiki/schema.md
+++ b/wiki/schema.md
@@ -1,0 +1,131 @@
+# Wiki Schema — LLM Wiki Maintenance Rules
+
+**Last Updated:** 2026-04-09
+**Maintained by:** Athena (CTO Agent)
+
+---
+
+## Overview
+
+This wiki follows the [LLM Wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) by Andrej Karpathy.
+
+**Three layers:**
+1. `raw/` — immutable source documents (research, articles, notes)
+2. `pages/` — LLM-generated markdown pages (summaries, entities, concepts)
+3. `schema.md` / `index.md` / `log.md` — this file + navigation + timeline
+
+---
+
+## Directory Structure
+
+```
+wiki/
+├── raw/                    # Source documents (NEVER modify)
+│   └── YYYY-MM-DD-*.md     # Named with date prefix
+├── pages/                  # LLM-generated wiki pages
+│   ├── index.md            # Auto-updated on every ingest
+│   ├── log.md              # Append-only activity log
+│   ├── entities/           # Individual stocks, features, people
+│   ├── concepts/           # Patterns, strategies, architectures
+│   ├── sources/            # Summary pages for each raw doc
+│   └── synthesis/          # High-level cross-cutting analysis
+├── schema.md               # This file
+└── index.md                # Auto-generated directory
+```
+
+---
+
+## Naming Conventions
+
+### Raw Files
+- `YYYY-MM-DD-topic-research.md` — e.g., `2026-04-02-dividend-ai-signals-research.md`
+- One topic per file
+
+### Wiki Pages
+- `entities/{slug}.md` — e.g., `entities/sharesight.md`, `entities/phase-19-ai-portfolio.md`
+- `concepts/{slug}.md` — e.g., `concepts/rag-patterns.md`, `concepts/open-finance-taiwan.md`
+- `sources/{slug}.md` — one per raw file, e.g., `sources/2026-04-02-dividend-ai-signals-research.md`
+- `synthesis/{slug}.md` — e.g., `synthesis/competitive-landscape.md`
+
+---
+
+## Frontmatter
+
+Every wiki page MUST have frontmatter:
+
+```markdown
+---
+title: Page Title
+tags: [research, fintech, open-finance]
+sources: [2026-04-02-dividend-ai-signals-research]
+created: 2026-04-09
+updated: 2026-04-09
+---
+
+# Page Title
+```
+
+---
+
+## Ingest Workflow
+
+When a new source is added to `raw/`:
+
+1. **Read** the source file completely
+2. **Create** `pages/sources/{filename}.md` — summary + key takeaways
+3. **Update** `index.md` — add entry for the new source page
+4. **Update relevant pages:**
+   - Extract entities → update `pages/entities/{entity}.md`
+   - Extract concepts → update `pages/concepts/{concept}.md`
+5. **Append** to `pages/log.md`: `## [YYYY-MM-DD] ingest | Source Title`
+6. **Flag contradictions** if new data conflicts with existing pages
+
+---
+
+## Query Workflow
+
+When Tony or a team member asks a question:
+
+1. **Read** `index.md` to find relevant pages
+2. **Read** relevant pages in full
+3. **Synthesize** answer
+4. **If answer is valuable:** Save as a new page in `pages/synthesis/`
+
+---
+
+## Lint Workflow
+
+Periodically (every 5 ingests or when asked):
+
+1. Check for orphan pages (no inbound links)
+2. Check for stale claims superseded by newer sources
+3. Check missing cross-references
+4. Check for important concepts mentioned but lacking pages
+5. Report findings in `pages/log.md`: `## [YYYY-MM-DD] lint | <findings>`
+
+---
+
+## Quality Standards
+
+- **No hallucination** — cite sources explicitly
+- **Cross-reference aggressively** — link to related pages
+- **Contradictions must be flagged** — use `> ⚠️ Contradicts: [page link]`
+- **Summary-first** — first paragraph = key takeaway, no preamble
+- **Frontmatter required** — tags, sources, dates
+
+---
+
+## What Goes in Wiki vs. Where
+
+| Content | Place |
+|---------|-------|
+| Market research, scout results | `raw/` + `pages/sources/` |
+| Feature analysis, competitive intel | `pages/synthesis/` |
+| Individual entities (stocks, apps) | `pages/entities/` |
+| Patterns, architectures, strategies | `pages/concepts/` |
+| Meeting notes, decisions | `raw/` (as source) |
+| Agent work logs | `pages/log.md` |
+
+---
+
+*This schema is co-evolved with Athena. Update when workflow changes.*


### PR DESCRIPTION
## Summary
- Wiki structure with structured pages (entities, concepts, sources, synthesis)
- build_graph.py — extracts links and entities from markdown files
- serve_graph.py — FastAPI server for graph Q&A endpoint
- Dockerfile.graphify — containerized graph builder
- docker-compose.graphify.yml — standalone graphify service
- Initial content migrated from research/ to wiki/raw/ and wiki/pages/

## Files Changed
```
Dockerfile.graphify
build_graph.py
docker-compose.graphify.yml
serve_graph.py
wiki/**/* (15 files)
```

## Testing
- [x] build_graph.py runs successfully locally
- [x] graph.json generated with correct structure
- [x] docker-compose config validated